### PR TITLE
응답 및 예외 구조를 세팅한다. 

### DIFF
--- a/api/src/main/java/com/dnd/book/support/error/ApiControllerAdvice.java
+++ b/api/src/main/java/com/dnd/book/support/error/ApiControllerAdvice.java
@@ -1,0 +1,34 @@
+package com.dnd.book.support.error;
+
+import com.dnd.book.support.response.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class ApiControllerAdvice {
+
+    @ExceptionHandler(ApiException.class)
+    public ResponseEntity<ApiResponse<?>> handleApiException(ApiException e) {
+        switch (e.getErrorType().getLogLevel()) {
+            case ERROR -> log.error("ApiException = {}", e.getMessage(), e);
+            case WARN -> log.warn("ApiException = {}", e.getMessage(), e);
+            default -> log.info("ApiException = {}", e.getMessage(), e);
+        }
+
+        return ResponseEntity
+                .status(e.getErrorType().getStatus())
+                .body(ApiResponse.error(e.getErrorType(), e.getData()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<?>> handleException(Exception e) {
+        log.error("Exception = {}", e.getMessage(), e);
+
+        return ResponseEntity
+                .status(ErrorType.DEFAULT_ERROR.getStatus())
+                .body(ApiResponse.error(ErrorType.DEFAULT_ERROR));
+    }
+}

--- a/api/src/main/java/com/dnd/book/support/error/ApiException.java
+++ b/api/src/main/java/com/dnd/book/support/error/ApiException.java
@@ -1,0 +1,22 @@
+package com.dnd.book.support.error;
+
+import lombok.Getter;
+
+@Getter
+public class ApiException extends RuntimeException {
+
+    private final ErrorType errorType;
+    private final Object data;
+
+    public ApiException(ErrorType errorType) {
+        super(errorType.getMessage());
+        this.errorType = errorType;
+        this.data = null;
+    }
+
+    public ApiException(ErrorType errorType, Object data) {
+        super(errorType.getMessage());
+        this.errorType = errorType;
+        this.data = data;
+    }
+}

--- a/api/src/main/java/com/dnd/book/support/error/ErrorCode.java
+++ b/api/src/main/java/com/dnd/book/support/error/ErrorCode.java
@@ -1,0 +1,9 @@
+package com.dnd.book.support.error;
+
+
+public enum ErrorCode {
+
+    // TODO: 에러 코드 추가 필요
+    E500,
+    E404,
+}

--- a/api/src/main/java/com/dnd/book/support/error/ErrorMessage.java
+++ b/api/src/main/java/com/dnd/book/support/error/ErrorMessage.java
@@ -1,0 +1,23 @@
+package com.dnd.book.support.error;
+
+import lombok.Getter;
+
+@Getter
+public class ErrorMessage {
+
+    private final String code;
+    private final String message;
+    private final Object data;
+
+    public ErrorMessage(ErrorType errorType) {
+        this.code = errorType.getCode().name();
+        this.message = errorType.getMessage();
+        this.data = null;
+    }
+
+    public ErrorMessage(ErrorType errorType, Object data) {
+        this.code = errorType.getCode().name();
+        this.message = errorType.getMessage();
+        this.data = data;
+    }
+}

--- a/api/src/main/java/com/dnd/book/support/error/ErrorType.java
+++ b/api/src/main/java/com/dnd/book/support/error/ErrorType.java
@@ -1,0 +1,30 @@
+package com.dnd.book.support.error;
+
+
+import lombok.Getter;
+import org.springframework.boot.logging.LogLevel;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorType {
+
+    // TODO: 에러 타입 정의 필요
+    DEFAULT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.E500,
+            "An unexpected error has occurred.", LogLevel.ERROR),
+
+    NOT_FOUND(HttpStatus.NOT_FOUND, ErrorCode.E404,
+            "The requested resource was not found.", LogLevel.INFO);
+
+
+    private final HttpStatus status;
+    private final ErrorCode code;
+    private final String message;
+    private final LogLevel logLevel;
+
+    ErrorType(HttpStatus status, ErrorCode code, String message, LogLevel logLevel) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+        this.logLevel = logLevel;
+    }
+}

--- a/api/src/main/java/com/dnd/book/support/response/ApiResponse.java
+++ b/api/src/main/java/com/dnd/book/support/response/ApiResponse.java
@@ -33,6 +33,6 @@ public class ApiResponse<S> {
     }
 
     public static ApiResponse<?> error(ErrorType error, Object errorData) {
-        return new ApiResponse<>(ResultType.ERROR, errorData, new ErrorMessage(error, errorData));
+        return new ApiResponse<>(ResultType.ERROR, null, new ErrorMessage(error, errorData));
     }
 }

--- a/api/src/main/java/com/dnd/book/support/response/ApiResponse.java
+++ b/api/src/main/java/com/dnd/book/support/response/ApiResponse.java
@@ -9,8 +9,8 @@ import lombok.Getter;
 public class ApiResponse<S> {
 
     private final ResultType resultType;
-    private final ErrorMessage error;
     private final S data;
+    private final ErrorMessage error;
 
 
     private ApiResponse(ResultType resultType, S data, ErrorMessage error) {

--- a/api/src/main/java/com/dnd/book/support/response/ApiResponse.java
+++ b/api/src/main/java/com/dnd/book/support/response/ApiResponse.java
@@ -1,0 +1,38 @@
+package com.dnd.book.support.response;
+
+
+import com.dnd.book.support.error.ErrorMessage;
+import com.dnd.book.support.error.ErrorType;
+import lombok.Getter;
+
+@Getter
+public class ApiResponse<S> {
+
+    private final ResultType resultType;
+    private final ErrorMessage error;
+    private final S data;
+
+
+    private ApiResponse(ResultType resultType, S data, ErrorMessage error) {
+        this.resultType = resultType;
+        this.data = data;
+        this.error = error;
+    }
+
+
+    public static ApiResponse<?> success() {
+        return new ApiResponse<>(ResultType.SUCCESS, null, null);
+    }
+
+    public static <S> ApiResponse<S> success(S data) {
+        return new ApiResponse<>(ResultType.SUCCESS, data, null);
+    }
+
+    public static ApiResponse<?> error(ErrorType error) {
+        return new ApiResponse<>(ResultType.ERROR, null, new ErrorMessage(error));
+    }
+
+    public static ApiResponse<?> error(ErrorType error, Object errorData) {
+        return new ApiResponse<>(ResultType.ERROR, errorData, new ErrorMessage(error, errorData));
+    }
+}

--- a/api/src/main/java/com/dnd/book/support/response/ResultType.java
+++ b/api/src/main/java/com/dnd/book/support/response/ResultType.java
@@ -1,0 +1,7 @@
+package com.dnd.book.support.response;
+
+public enum ResultType {
+
+    SUCCESS,
+    ERROR,
+}


### PR DESCRIPTION
## 연관된 이슈

resolves #5 

## 작업 내용

- api 모듈에 응답과 예외 구조를 세팅하였습니다. 

**아래는 응답 예시입니다.**

_success response_

```json
{
    "resultType": "SUCCESS",
    "error": null,
    "data": {
        "key": "value"
    }
}
```

_error response_

```json
{
    "resultType": "ERROR",
    "error": {
        "code": "E500",
        "message": "An unexpected error has occurred.",
        "data": null
    },
    "data": null
}

```



## 리뷰 요구사항

1. 예외 응답(ErrorType)의 메시지를 영어로 해야할까요? 
2. ErrorType, ErrorCode 의 경우 개발을 하면서 필요한 경우에 추가해서 사용하면 될 것 같아요!

