### PR TITLE
Swagger Failed load remote Configuration 해결

### DIFF
--- a/api/src/main/java/com/dnd/book/security/SecurityConfig.java
+++ b/api/src/main/java/com/dnd/book/security/SecurityConfig.java
@@ -28,9 +28,13 @@ public class SecurityConfig {
     private final TokenAuthenticationFilter tokenAuthenticationFilter;
     private final ObjectMapper objectMapper;
     private static final String[] allowUrls = {
-            "/swagger-ui/**",
             "/swagger-resources/**",
-            "/v3/api-docs/**"
+            "/swagger-ui/**",
+            "/swagger-ui.html",
+            "/v3/api-docs/**",
+            "/v3/api-docs",
+            "/api-docs/**",
+            "/api-docs"
     };
     @Bean
     WebSecurityCustomizer webSecurityCustomizer() {


### PR DESCRIPTION
## 연관된 이슈

closes #20 

## 작업 내용

Security의 allowUrls에 swagger 관련 경로 추가하여 permitAll() 수행
