### PR TITLE
Swagger Request URL이 잘못 나오는 문제를 해결하고, Swagger 세팅을 한다.

### DIFF
--- a/api/src/main/java/com/dnd/book/docs/SwaggerConfig.java
+++ b/api/src/main/java/com/dnd/book/docs/SwaggerConfig.java
@@ -2,6 +2,7 @@ package com.dnd.book.docs;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
 import io.swagger.v3.oas.models.servers.Server;
 import jakarta.servlet.ServletContext;
 import org.springframework.context.annotation.Bean;
@@ -25,8 +26,12 @@ public class SwaggerConfig {
     }
 
     private Info info() {
+        License license = new License();
+        license.setUrl("https://github.com/dnd-side-project/dnd-12th-9-backend");
+        license.setName("Sbooky API License");
+
         return new Info()
-                .title("Book API")
+                .title("Sbooky API")
                 .description("[DND 12-9] 프로젝트 API 명세서입니다.")
                 .version("v1.0.0");
     }

--- a/api/src/main/java/com/dnd/book/docs/SwaggerConfig.java
+++ b/api/src/main/java/com/dnd/book/docs/SwaggerConfig.java
@@ -3,6 +3,7 @@ package com.dnd.book.docs;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.servers.Server;
+import jakarta.servlet.ServletContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -15,12 +16,12 @@ public class SwaggerConfig {
 
     @Bean
     @Profile("!prod") // prod 환경에서는 Swagger 비활성
-    public OpenAPI customOpenAPI() {
-
-        // todo: Spring Security 적용 시 인증 토큰 관련 정보를 추가해야 한다.
+    public OpenAPI customOpenAPI(ServletContext servletContext) {
+        String contextPath = servletContext.getContextPath();
+        Server server = new Server().url(contextPath);
         return new OpenAPI()
                 .info(info())
-                .servers(servers());
+                .servers(List.of(server));
     }
 
     private Info info() {
@@ -28,17 +29,5 @@ public class SwaggerConfig {
                 .title("Book API")
                 .description("[DND 12-9] 프로젝트 API 명세서입니다.")
                 .version("v1.0.0");
-    }
-
-    private List<Server> servers() {
-        Server devServer = new Server()
-                .url("/dev.url.com")
-                .description("개발 환경 서버 URL");
-
-        Server prodServer = new Server()
-                .url("/prod.url.com")
-                .description("운영 환경 서버 URL");
-
-        return List.of(devServer, prodServer);
     }
 }

--- a/api/src/main/java/com/dnd/book/docs/SwaggerConfig.java
+++ b/api/src/main/java/com/dnd/book/docs/SwaggerConfig.java
@@ -1,8 +1,10 @@
 package com.dnd.book.docs;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import jakarta.servlet.ServletContext;
 import org.springframework.context.annotation.Bean;
@@ -14,7 +16,6 @@ import java.util.List;
 @Configuration
 public class SwaggerConfig {
 
-
     @Bean
     @Profile("!prod") // prod 환경에서는 Swagger 비활성
     public OpenAPI customOpenAPI(ServletContext servletContext) {
@@ -22,7 +23,8 @@ public class SwaggerConfig {
         Server server = new Server().url(contextPath);
         return new OpenAPI()
                 .info(info())
-                .servers(List.of(server));
+                .servers(List.of(server))
+                .components(authSetting());
     }
 
     private Info info() {
@@ -34,5 +36,17 @@ public class SwaggerConfig {
                 .title("Sbooky API")
                 .description("[DND 12-9] 프로젝트 API 명세서입니다.")
                 .version("v1.0.0");
+    }
+
+    private Components authSetting() {
+        return new Components()
+                .addSecuritySchemes(
+                        "access-token",
+                        new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .in(SecurityScheme.In.HEADER)
+                                .name("Authorization"));
     }
 }

--- a/api/src/main/java/com/dnd/book/docs/SwaggerConfig.java
+++ b/api/src/main/java/com/dnd/book/docs/SwaggerConfig.java
@@ -20,7 +20,7 @@ public class SwaggerConfig {
     @Profile("!prod") // prod 환경에서는 Swagger 비활성
     public OpenAPI customOpenAPI(ServletContext servletContext) {
         String contextPath = servletContext.getContextPath();
-        Server server = new Server().url(contextPath);
+        Server server = new Server().url(contextPath).description("Sbooky API");
         return new OpenAPI()
                 .info(info())
                 .servers(List.of(server))

--- a/api/src/main/java/com/dnd/book/docs/controller/RegisterBookControllerDocs.java
+++ b/api/src/main/java/com/dnd/book/docs/controller/RegisterBookControllerDocs.java
@@ -1,9 +1,9 @@
 package com.dnd.book.docs.controller;
 
 import com.dnd.book.book.request.RegisterBookRequest;
-import com.dnd.book.member.MemberEntity;
 import com.dnd.book.support.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.security.core.userdetails.UserDetails;
 
@@ -11,6 +11,7 @@ import org.springframework.security.core.userdetails.UserDetails;
         name = "[Book API]",
         description = "책 등록에 관련된 API"
 )
+@SecurityRequirement(name = "access-token")
 public interface RegisterBookControllerDocs {
 
     @Operation(summary = "책 등록", description = "회원이 새로운 책을 등록한다.")


### PR DESCRIPTION
## 연관된 이슈

closes #24 

## 작업 내용

- Swagger pefix에 contextPath가 있도록 수정
- Swagger에 Authorize 기능 추가

## 공유할 것

Swagger에 Authorize 기능을 적용하고 싶은 API에 @SecurityRequirement(name = "access-token")을 붙여주시면 됩니다.

<img width="699" alt="스크린샷 2025-01-29 오후 3 47 47" src="https://github.com/user-attachments/assets/faa55238-9c2a-4fe1-aa11-28099ffb6b4a" />

## 리뷰 요구사항

카카오 로그인 페이지로 redirect 하는 /login과 같은 URL은 보여줘야할까요? 아니면 slack에 언급만 해도 괜찮을까요?
