### PR TITLE
회원의 케릭터에 좋아요를 누른다.

### DIFF
--- a/api/src/main/java/com/dnd/sbooky/api/docs/spec/AddLikeApiSpec.java
+++ b/api/src/main/java/com/dnd/sbooky/api/docs/spec/AddLikeApiSpec.java
@@ -1,0 +1,13 @@
+package com.dnd.sbooky.api.docs.spec;
+
+import com.dnd.sbooky.api.member.reqeust.AddLikeRequest;
+import com.dnd.sbooky.api.support.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "[Like API]", description = "좋아요에 관련된 API")
+public interface AddLikeApiSpec {
+
+    @Operation(summary = "좋아요 요청", description = "방문자가 좋아요를 누르는 횟수를 반영한다.")
+    ApiResponse<?> addLikes(AddLikeRequest request);
+}

--- a/api/src/main/java/com/dnd/sbooky/api/member/AddLikeController.java
+++ b/api/src/main/java/com/dnd/sbooky/api/member/AddLikeController.java
@@ -1,0 +1,24 @@
+package com.dnd.sbooky.api.member;
+
+import com.dnd.sbooky.api.docs.spec.AddLikeApiSpec;
+import com.dnd.sbooky.api.member.reqeust.AddLikeRequest;
+import com.dnd.sbooky.api.support.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class AddLikeController implements AddLikeApiSpec {
+
+    private final AddLikeUsecase addLikeUsecase;
+
+    @PatchMapping("/likes")
+    public ApiResponse<?> addLikes(@Valid @RequestBody AddLikeRequest request) {
+        return ApiResponse.success(addLikeUsecase.add(request.memberId(), request.addCount()));
+    }
+}

--- a/api/src/main/java/com/dnd/sbooky/api/member/AddLikeUsecase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/member/AddLikeUsecase.java
@@ -1,0 +1,25 @@
+package com.dnd.sbooky.api.member;
+
+import com.dnd.sbooky.api.book.exception.MemberNotFoundException;
+import com.dnd.sbooky.api.support.error.ErrorType;
+import com.dnd.sbooky.core.like.LikeEntity;
+import com.dnd.sbooky.core.like.LikeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AddLikeUsecase {
+
+    private final LikeRepository likeRepository;
+
+    public Long add(Long memberId, Long addCount) {
+        LikeEntity likeEntity =
+                likeRepository
+                        .findById(memberId)
+                        .orElseThrow(() -> new MemberNotFoundException(ErrorType.MEMBER_NOT_FOUND));
+        return likeEntity.add(addCount);
+    }
+}

--- a/api/src/main/java/com/dnd/sbooky/api/member/reqeust/AddLikeRequest.java
+++ b/api/src/main/java/com/dnd/sbooky/api/member/reqeust/AddLikeRequest.java
@@ -1,0 +1,9 @@
+package com.dnd.sbooky.api.member.reqeust;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "좋아요 요청 DTO")
+public record AddLikeRequest(
+        @Schema(description = "주인 식별자") @NotNull Long memberId,
+        @Schema(description = "추가할 좋아요 수") @NotNull Long addCount) {}

--- a/api/src/main/java/com/dnd/sbooky/api/security/CustomOAuth2UserService.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/CustomOAuth2UserService.java
@@ -1,5 +1,7 @@
 package com.dnd.sbooky.api.security;
 
+import com.dnd.sbooky.core.like.LikeEntity;
+import com.dnd.sbooky.core.like.LikeRepository;
 import com.dnd.sbooky.core.member.MemberEntity;
 import com.dnd.sbooky.core.member.MemberRepository;
 import java.util.Map;
@@ -15,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     private final MemberRepository memberRepository;
+    private final LikeRepository likeRepository;
 
     /**
      * kakaoId와 registrationId로 회원을 찾거나 저장한다.
@@ -47,6 +50,8 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                         .findByKakaoIdAndRegistrationId(
                                 oAuth2UserDTO.kakaoId(), oAuth2UserDTO.registrationId())
                         .orElseGet(oAuth2UserDTO::toEntity);
-        return memberRepository.save(member);
+        MemberEntity memberEntity = memberRepository.save(member);
+        likeRepository.save(LikeEntity.newInstance(memberEntity.getId()));
+        return memberEntity;
     }
 }

--- a/api/src/main/java/com/dnd/sbooky/api/security/SecurityConfig.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/SecurityConfig.java
@@ -35,7 +35,8 @@ public class SecurityConfig {
         "/v3/api-docs",
         "/api-docs/**",
         "/api-docs",
-        "/api/auth/reissue"
+        "/api/auth/reissue",
+        "/api/likes"
     };
 
     @Bean

--- a/core/src/main/java/com/dnd/sbooky/core/like/LikeEntity.java
+++ b/core/src/main/java/com/dnd/sbooky/core/like/LikeEntity.java
@@ -1,0 +1,22 @@
+package com.dnd.sbooky.core.like;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "likes")
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LikeEntity {
+    private static final String ENTITY_PREFIX = "likes";
+    public static final long START_COUNT = 0L;
+
+    @Id
+    @Column(name = ENTITY_PREFIX + "_id")
+    private Long id;
+
+    @Column(name = ENTITY_PREFIX + "_count")
+    private Long count;
+}

--- a/core/src/main/java/com/dnd/sbooky/core/like/LikeEntity.java
+++ b/core/src/main/java/com/dnd/sbooky/core/like/LikeEntity.java
@@ -19,4 +19,8 @@ public class LikeEntity {
 
     @Column(name = ENTITY_PREFIX + "_count")
     private Long count;
+
+    public static LikeEntity newInstance(Long likeId) {
+        return new LikeEntity(likeId, START_COUNT);
+    }
 }

--- a/core/src/main/java/com/dnd/sbooky/core/like/LikeEntity.java
+++ b/core/src/main/java/com/dnd/sbooky/core/like/LikeEntity.java
@@ -23,4 +23,9 @@ public class LikeEntity {
     public static LikeEntity newInstance(Long likeId) {
         return new LikeEntity(likeId, START_COUNT);
     }
+
+    public Long add(long count) {
+        this.count += count;
+        return this.count;
+    }
 }

--- a/core/src/main/java/com/dnd/sbooky/core/like/LikeRepository.java
+++ b/core/src/main/java/com/dnd/sbooky/core/like/LikeRepository.java
@@ -1,0 +1,5 @@
+package com.dnd.sbooky.core.like;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LikeRepository extends JpaRepository<LikeEntity, Long> {}


### PR DESCRIPTION
## 연관된 이슈

(https://github.com/dnd-side-project/dnd-12th-9-backend/issues/36)

## 작업 내용

LikeEntity 설계

```java
@Entity
@Table(name = "likes")
@AllArgsConstructor(access = AccessLevel.PRIVATE)
@NoArgsConstructor(access = AccessLevel.PROTECTED)
public class LikeEntity {
    private static final String ENTITY_PREFIX = "likes";

    @Id
    @Column(name = ENTITY_PREFIX + "_id")
    private Long id;


    @Column(name = ENTITY_PREFIX + "_count")
    private String count;
}
```

**MemberEntity의 PK를 LikeEntity의 PK로 활용**
특정 회원의 좋아요 정보를 조회할 때 인덱스를 효율적으로 활용할 수 있습니다. 이를 통해 조회 성능을 개선하고, 불필요한 인덱스 탐색 비용을 줄일 수 있습니다.

**외래 키(FK) 저장 공간 절약**
LikeEntity와 MemberEntity 간의 연관관계를 설정하면 기본적으로 FK 컬럼이 추가됩니다. 그러나 LikeEntity의 PK를 MemberEntity의 PK와 동일하게 설정하면 별도의 FK 저장이 필요 없으므로, 데이터베이스 용량을 절약할 수 있습니다.

**MemberEntity에 count 필드 추가 시 고려사항**
좋아요 개수를 저장하는 count 필드를 MemberEntity에 추가할 경우, 좋아요 증가/감소 시 해당 레코드에 대한 락(Lock)이 발생합니다. 이는 다른 회원의 수정 요청을 지연시킬 수 있어, 동시성 처리를 고려해야 합니다.


## 리뷰 요구사항

> 동시성 문제는 다음 PR에서 테스트하고 반영하는 방향을 생각하고 있는 데 괜찮을까요?