### PR TITLE
좋아요 동시성 문제를 해결한다.

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
 
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 

--- a/api/src/main/java/com/dnd/sbooky/api/docs/spec/AddLikeApiSpec.java
+++ b/api/src/main/java/com/dnd/sbooky/api/docs/spec/AddLikeApiSpec.java
@@ -1,6 +1,6 @@
 package com.dnd.sbooky.api.docs.spec;
 
-import com.dnd.sbooky.api.member.reqeust.AddLikeRequest;
+import com.dnd.sbooky.api.like.reqeust.AddLikeRequest;
 import com.dnd.sbooky.api.support.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/api/src/main/java/com/dnd/sbooky/api/like/AddLikeController.java
+++ b/api/src/main/java/com/dnd/sbooky/api/like/AddLikeController.java
@@ -1,7 +1,7 @@
-package com.dnd.sbooky.api.member;
+package com.dnd.sbooky.api.like;
 
 import com.dnd.sbooky.api.docs.spec.AddLikeApiSpec;
-import com.dnd.sbooky.api.member.reqeust.AddLikeRequest;
+import com.dnd.sbooky.api.like.reqeust.AddLikeRequest;
 import com.dnd.sbooky.api.support.response.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/api/src/main/java/com/dnd/sbooky/api/like/AddLikeUsecase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/like/AddLikeUsecase.java
@@ -18,7 +18,7 @@ public class AddLikeUsecase {
     public Long add(Long memberId, Long addCount) {
         LikeEntity likeEntity =
                 likeRepository
-                        .findById(memberId)
+                        .findByIdWithPessimisticLock(memberId)
                         .orElseThrow(() -> new MemberNotFoundException(ErrorType.MEMBER_NOT_FOUND));
         return likeEntity.add(addCount);
     }

--- a/api/src/main/java/com/dnd/sbooky/api/like/AddLikeUsecase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/like/AddLikeUsecase.java
@@ -1,4 +1,4 @@
-package com.dnd.sbooky.api.member;
+package com.dnd.sbooky.api.like;
 
 import com.dnd.sbooky.api.book.exception.MemberNotFoundException;
 import com.dnd.sbooky.api.support.error.ErrorType;

--- a/api/src/main/java/com/dnd/sbooky/api/like/reqeust/AddLikeRequest.java
+++ b/api/src/main/java/com/dnd/sbooky/api/like/reqeust/AddLikeRequest.java
@@ -1,4 +1,4 @@
-package com.dnd.sbooky.api.member.reqeust;
+package com.dnd.sbooky.api.like.reqeust;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;

--- a/core/src/main/java/com/dnd/sbooky/core/LockTimeout.java
+++ b/core/src/main/java/com/dnd/sbooky/core/LockTimeout.java
@@ -1,0 +1,14 @@
+package com.dnd.sbooky.core;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface LockTimeout {
+    int timeout() default 3; // 3초
+}

--- a/core/src/main/java/com/dnd/sbooky/core/LockTimeoutAspect.java
+++ b/core/src/main/java/com/dnd/sbooky/core/LockTimeoutAspect.java
@@ -1,0 +1,22 @@
+package com.dnd.sbooky.core;
+
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class LockTimeoutAspect {
+    private final LockTimeoutRepository lockTimeoutRepository;
+
+    @Before("@annotation(com.dnd.sbooky.core.LockTimeout)")
+    public void setTimeoutBeforeLock(JoinPoint joinPoint) {
+        MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
+        LockTimeout lockTimeout = methodSignature.getMethod().getAnnotation(LockTimeout.class);
+        lockTimeoutRepository.setInnodbLockWaitTimeout(lockTimeout.timeout());
+    }
+}

--- a/core/src/main/java/com/dnd/sbooky/core/LockTimeoutRepository.java
+++ b/core/src/main/java/com/dnd/sbooky/core/LockTimeoutRepository.java
@@ -1,0 +1,21 @@
+package com.dnd.sbooky.core;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class LockTimeoutRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public LockTimeoutRepository(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public void setInnodbLockWaitTimeout(int seconds) {
+        System.out.println("setInnodbLockWaitTimeout: " + seconds);
+        jdbcTemplate.execute("SET SESSION lock_wait_timeout = " + seconds);
+    }
+}
+
+

--- a/core/src/main/java/com/dnd/sbooky/core/LockTimeoutRepository.java
+++ b/core/src/main/java/com/dnd/sbooky/core/LockTimeoutRepository.java
@@ -1,20 +1,16 @@
 package com.dnd.sbooky.core;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
 @Repository
+@RequiredArgsConstructor
 public class LockTimeoutRepository {
 
     private final JdbcTemplate jdbcTemplate;
-
-    public LockTimeoutRepository(JdbcTemplate jdbcTemplate) {
-        this.jdbcTemplate = jdbcTemplate;
-    }
 
     public void setInnodbLockWaitTimeout(int seconds) {
         jdbcTemplate.execute("SET SESSION lock_wait_timeout = " + seconds);
     }
 }
-
-

--- a/core/src/main/java/com/dnd/sbooky/core/LockTimeoutRepository.java
+++ b/core/src/main/java/com/dnd/sbooky/core/LockTimeoutRepository.java
@@ -13,7 +13,6 @@ public class LockTimeoutRepository {
     }
 
     public void setInnodbLockWaitTimeout(int seconds) {
-        System.out.println("setInnodbLockWaitTimeout: " + seconds);
         jdbcTemplate.execute("SET SESSION lock_wait_timeout = " + seconds);
     }
 }

--- a/core/src/main/java/com/dnd/sbooky/core/MemberInitializer.java
+++ b/core/src/main/java/com/dnd/sbooky/core/MemberInitializer.java
@@ -1,5 +1,7 @@
 package com.dnd.sbooky.core;
 
+import com.dnd.sbooky.core.like.LikeEntity;
+import com.dnd.sbooky.core.like.LikeRepository;
 import com.dnd.sbooky.core.member.MemberEntity;
 import com.dnd.sbooky.core.member.MemberRepository;
 import jakarta.annotation.PostConstruct;
@@ -11,9 +13,11 @@ import org.springframework.stereotype.Component;
 public class MemberInitializer {
 
     private final MemberRepository memberRepository;
+    private final LikeRepository likeRepository;
 
     @PostConstruct
     public void init() {
-        memberRepository.save(MemberEntity.newInstance("test1", "test1"));
+        MemberEntity memberEntity = memberRepository.save(MemberEntity.newInstance("test1", "test1"));
+        likeRepository.save(LikeEntity.newInstance(memberEntity.getId()));
     }
 }

--- a/core/src/main/java/com/dnd/sbooky/core/MemberInitializer.java
+++ b/core/src/main/java/com/dnd/sbooky/core/MemberInitializer.java
@@ -17,7 +17,8 @@ public class MemberInitializer {
 
     @PostConstruct
     public void init() {
-        MemberEntity memberEntity = memberRepository.save(MemberEntity.newInstance("test1", "test1"));
+        MemberEntity memberEntity =
+                memberRepository.save(MemberEntity.newInstance("test1", "test1"));
         likeRepository.save(LikeEntity.newInstance(memberEntity.getId()));
     }
 }

--- a/core/src/main/java/com/dnd/sbooky/core/like/LikeRepository.java
+++ b/core/src/main/java/com/dnd/sbooky/core/like/LikeRepository.java
@@ -1,5 +1,13 @@
 package com.dnd.sbooky.core.like;
 
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
-public interface LikeRepository extends JpaRepository<LikeEntity, Long> {}
+public interface LikeRepository extends JpaRepository<LikeEntity, Long> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select l from LikeEntity l where l.id = :id")
+    Optional<LikeEntity> findByIdWithPessimisticLock(Long id);
+}

--- a/core/src/main/java/com/dnd/sbooky/core/like/LikeRepository.java
+++ b/core/src/main/java/com/dnd/sbooky/core/like/LikeRepository.java
@@ -1,5 +1,6 @@
 package com.dnd.sbooky.core.like;
 
+import com.dnd.sbooky.core.LockTimeout;
 import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface LikeRepository extends JpaRepository<LikeEntity, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @LockTimeout
     @Query("select l from LikeEntity l where l.id = :id")
     Optional<LikeEntity> findByIdWithPessimisticLock(Long id);
 }

--- a/core/src/main/resources/core.yml
+++ b/core/src/main/resources/core.yml
@@ -24,6 +24,11 @@ spring:
     port: 6379
     password: 1234
 
+logging:
+  level:
+    org:
+      springframework:
+        jdbc: debug
 core:
   datasource:
     jdbc-url: jdbc:mysql://localhost:3306/sbooky?serverTimezone=Asia/Seoul


### PR DESCRIPTION
## 연관된 이슈

https://github.com/dnd-side-project/dnd-12th-9-backend/issues/46

## 작업 내용

여러 사용자가 동시에 중복 관계없이 좋아요를 누를 수 있음을 고려해 X Lock을 적용하였습니다.

- Optimistic Lock은 충돌 발생 시 데이터를 다시 조회해야 하므로 성능 저하가 우려되어 적합하지 않다고 판단
- Pessimistic Lock은 동시성 문제를 해결할 수 있으나, 다수의 쓰기 요청이 있을 때 효과적일지 의문
- Lettuce 기반 분산 락은 동시성 문제를 해결 가능하나, Spin lock 방식으로 Redis 부하를 초래할 가능성 있음.
- Redisson 기반 분산 락은 동시성 문제를 해결할 수 있으며, pub/sub 모델을 활용해 Redis 부하를 줄이고, 락 획득 재시도를 라이브러리 차원에서 지원


좋아요 기능의 특성을 고려할 때 비관적 락 또는 Redisson 적용이 적절해 보이며, 현재 서버가 1대이므로 구현이 용이한 비관적 락을 우선 적용하기로 결정했습니다. 이후 서버가 확장될 가능성을 고려해 테스트를 진행하며 Redisson과 비교할 예정

## 리뷰 요구사항

어떤 락을 적용할 지 고민해봤는데 같이 이야기해보면 좋을 거 같아요.

