### PR TITLE
좋아요 수를 조회한다.

### DIFF
--- a/api/src/main/java/com/dnd/sbooky/api/book/FindBookUseCase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/book/FindBookUseCase.java
@@ -2,7 +2,7 @@ package com.dnd.sbooky.api.book;
 
 import com.dnd.sbooky.api.book.exception.BookForbiddenException;
 import com.dnd.sbooky.api.book.exception.BookNotFoundException;
-import com.dnd.sbooky.api.book.exception.MemberNotFoundException;
+import com.dnd.sbooky.api.member.exception.MemberNotFoundException;
 import com.dnd.sbooky.api.book.response.FindAllBookResponse;
 import com.dnd.sbooky.api.book.response.FindBookDetailsResponse;
 import com.dnd.sbooky.api.support.error.ErrorType;

--- a/api/src/main/java/com/dnd/sbooky/api/book/FindBookUseCase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/book/FindBookUseCase.java
@@ -2,9 +2,9 @@ package com.dnd.sbooky.api.book;
 
 import com.dnd.sbooky.api.book.exception.BookForbiddenException;
 import com.dnd.sbooky.api.book.exception.BookNotFoundException;
-import com.dnd.sbooky.api.member.exception.MemberNotFoundException;
 import com.dnd.sbooky.api.book.response.FindAllBookResponse;
 import com.dnd.sbooky.api.book.response.FindBookDetailsResponse;
+import com.dnd.sbooky.api.member.exception.MemberNotFoundException;
 import com.dnd.sbooky.api.support.error.ErrorType;
 import com.dnd.sbooky.core.book.MemberBookEntity;
 import com.dnd.sbooky.core.book.MemberBookRepository;

--- a/api/src/main/java/com/dnd/sbooky/api/book/UpdateBookUseCase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/book/UpdateBookUseCase.java
@@ -1,8 +1,8 @@
 package com.dnd.sbooky.api.book;
 
 import com.dnd.sbooky.api.book.exception.BookForbiddenException;
-import com.dnd.sbooky.api.member.exception.MemberNotFoundException;
 import com.dnd.sbooky.api.book.request.UpdateBookRequest;
+import com.dnd.sbooky.api.member.exception.MemberNotFoundException;
 import com.dnd.sbooky.api.support.error.ErrorType;
 import com.dnd.sbooky.core.book.BookEntity;
 import com.dnd.sbooky.core.book.MemberBookEntity;

--- a/api/src/main/java/com/dnd/sbooky/api/book/UpdateBookUseCase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/book/UpdateBookUseCase.java
@@ -1,7 +1,7 @@
 package com.dnd.sbooky.api.book;
 
 import com.dnd.sbooky.api.book.exception.BookForbiddenException;
-import com.dnd.sbooky.api.book.exception.MemberNotFoundException;
+import com.dnd.sbooky.api.member.exception.MemberNotFoundException;
 import com.dnd.sbooky.api.book.request.UpdateBookRequest;
 import com.dnd.sbooky.api.support.error.ErrorType;
 import com.dnd.sbooky.core.book.BookEntity;

--- a/api/src/main/java/com/dnd/sbooky/api/docs/spec/GetLikesApiSpec.java
+++ b/api/src/main/java/com/dnd/sbooky/api/docs/spec/GetLikesApiSpec.java
@@ -1,0 +1,11 @@
+package com.dnd.sbooky.api.docs.spec;
+
+import com.dnd.sbooky.api.support.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "[Like API]", description = "좋아요에 관련된 API")
+public interface GetLikesApiSpec {
+    @Operation(summary = "방문자용 좋아요 수 조회", description = "방문자가 회원의 좋아요 수를 조회한다.")
+    ApiResponse<?> getLikes(Long memberId);
+}

--- a/api/src/main/java/com/dnd/sbooky/api/docs/spec/GetLikesApiSpec.java
+++ b/api/src/main/java/com/dnd/sbooky/api/docs/spec/GetLikesApiSpec.java
@@ -2,16 +2,10 @@ package com.dnd.sbooky.api.docs.spec;
 
 import com.dnd.sbooky.api.support.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.security.core.userdetails.UserDetails;
 
 @Tag(name = "[Like API]", description = "좋아요에 관련된 API")
 public interface GetLikesApiSpec {
-    @Operation(summary = "방문자용 좋아요 수 조회", description = "방문자가 회원의 좋아요 수를 조회한다.")
+    @Operation(summary = "좋아요 수 조회", description = "회원의 좋아요 수를 조회한다.")
     ApiResponse<?> getLikes(Long memberId);
-
-    @SecurityRequirement(name = "access-token")
-    @Operation(summary = "호스타용 좋아요 수 조회", description = "호스트가 회원의 좋아요 수를 조회한다.")
-    ApiResponse<?> getLikes(UserDetails user);
 }

--- a/api/src/main/java/com/dnd/sbooky/api/docs/spec/GetLikesApiSpec.java
+++ b/api/src/main/java/com/dnd/sbooky/api/docs/spec/GetLikesApiSpec.java
@@ -2,10 +2,16 @@ package com.dnd.sbooky.api.docs.spec;
 
 import com.dnd.sbooky.api.support.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.core.userdetails.UserDetails;
 
 @Tag(name = "[Like API]", description = "좋아요에 관련된 API")
 public interface GetLikesApiSpec {
     @Operation(summary = "방문자용 좋아요 수 조회", description = "방문자가 회원의 좋아요 수를 조회한다.")
     ApiResponse<?> getLikes(Long memberId);
+
+    @SecurityRequirement(name = "access-token")
+    @Operation(summary = "호스타용 좋아요 수 조회", description = "호스트가 회원의 좋아요 수를 조회한다.")
+    ApiResponse<?> getLikes(UserDetails user);
 }

--- a/api/src/main/java/com/dnd/sbooky/api/like/AddLikeUsecase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/like/AddLikeUsecase.java
@@ -1,6 +1,6 @@
 package com.dnd.sbooky.api.like;
 
-import com.dnd.sbooky.api.book.exception.MemberNotFoundException;
+import com.dnd.sbooky.api.member.exception.MemberNotFoundException;
 import com.dnd.sbooky.api.support.error.ErrorType;
 import com.dnd.sbooky.core.like.LikeEntity;
 import com.dnd.sbooky.core.like.LikeRepository;

--- a/api/src/main/java/com/dnd/sbooky/api/like/GetLikesController.java
+++ b/api/src/main/java/com/dnd/sbooky/api/like/GetLikesController.java
@@ -1,0 +1,23 @@
+package com.dnd.sbooky.api.like;
+
+import com.dnd.sbooky.api.docs.spec.GetLikesApiSpec;
+import com.dnd.sbooky.api.like.response.GetLikesResponse;
+import com.dnd.sbooky.api.support.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class GetLikesController implements GetLikesApiSpec {
+
+    private final GetLikesUsecase getLikesUsecase;
+
+    @GetMapping("/likes/{memberId}")
+    public ApiResponse<?> getLikes(@PathVariable Long memberId) {
+        return ApiResponse.success(GetLikesResponse.from(getLikesUsecase.get(memberId)));
+    }
+}

--- a/api/src/main/java/com/dnd/sbooky/api/like/GetLikesController.java
+++ b/api/src/main/java/com/dnd/sbooky/api/like/GetLikesController.java
@@ -20,12 +20,12 @@ public class GetLikesController implements GetLikesApiSpec {
     private final GetLikesUsecase getLikesUsecase;
 
     @GetMapping("/likes/{memberId}")
-    public ApiResponse<?> getLikes(@PathVariable Long memberId) {
+    public ApiResponse<GetLikesResponse> getLikes(@PathVariable Long memberId) {
         return ApiResponse.success(GetLikesResponse.from(getLikesUsecase.get(memberId)));
     }
 
     @GetMapping("/likes")
-    public ApiResponse<?> getLikes(
+    public ApiResponse<GetLikesResponse> getLikes(
             @Parameter(hidden = true) @AuthenticationPrincipal UserDetails user) {
         return ApiResponse.success(
                 GetLikesResponse.from(getLikesUsecase.get(Long.valueOf(user.getUsername()))));

--- a/api/src/main/java/com/dnd/sbooky/api/like/GetLikesController.java
+++ b/api/src/main/java/com/dnd/sbooky/api/like/GetLikesController.java
@@ -3,7 +3,10 @@ package com.dnd.sbooky.api.like;
 import com.dnd.sbooky.api.docs.spec.GetLikesApiSpec;
 import com.dnd.sbooky.api.like.response.GetLikesResponse;
 import com.dnd.sbooky.api.support.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,5 +22,12 @@ public class GetLikesController implements GetLikesApiSpec {
     @GetMapping("/likes/{memberId}")
     public ApiResponse<?> getLikes(@PathVariable Long memberId) {
         return ApiResponse.success(GetLikesResponse.from(getLikesUsecase.get(memberId)));
+    }
+
+    @GetMapping("/likes")
+    public ApiResponse<?> getLikes(
+            @Parameter(hidden = true) @AuthenticationPrincipal UserDetails user) {
+        return ApiResponse.success(
+                GetLikesResponse.from(getLikesUsecase.get(Long.valueOf(user.getUsername()))));
     }
 }

--- a/api/src/main/java/com/dnd/sbooky/api/like/GetLikesController.java
+++ b/api/src/main/java/com/dnd/sbooky/api/like/GetLikesController.java
@@ -3,10 +3,7 @@ package com.dnd.sbooky.api.like;
 import com.dnd.sbooky.api.docs.spec.GetLikesApiSpec;
 import com.dnd.sbooky.api.like.response.GetLikesResponse;
 import com.dnd.sbooky.api.support.response.ApiResponse;
-import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,12 +19,5 @@ public class GetLikesController implements GetLikesApiSpec {
     @GetMapping("/likes/{memberId}")
     public ApiResponse<GetLikesResponse> getLikes(@PathVariable Long memberId) {
         return ApiResponse.success(GetLikesResponse.from(getLikesUsecase.get(memberId)));
-    }
-
-    @GetMapping("/likes")
-    public ApiResponse<GetLikesResponse> getLikes(
-            @Parameter(hidden = true) @AuthenticationPrincipal UserDetails user) {
-        return ApiResponse.success(
-                GetLikesResponse.from(getLikesUsecase.get(Long.valueOf(user.getUsername()))));
     }
 }

--- a/api/src/main/java/com/dnd/sbooky/api/like/GetLikesUsecase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/like/GetLikesUsecase.java
@@ -1,6 +1,6 @@
 package com.dnd.sbooky.api.like;
 
-import com.dnd.sbooky.api.book.exception.MemberNotFoundException;
+import com.dnd.sbooky.api.member.exception.MemberNotFoundException;
 import com.dnd.sbooky.api.support.error.ErrorType;
 import com.dnd.sbooky.core.like.LikeEntity;
 import com.dnd.sbooky.core.like.LikeRepository;

--- a/api/src/main/java/com/dnd/sbooky/api/like/GetLikesUsecase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/like/GetLikesUsecase.java
@@ -1,0 +1,24 @@
+package com.dnd.sbooky.api.like;
+
+import com.dnd.sbooky.api.book.exception.MemberNotFoundException;
+import com.dnd.sbooky.api.support.error.ErrorType;
+import com.dnd.sbooky.core.like.LikeEntity;
+import com.dnd.sbooky.core.like.LikeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class GetLikesUsecase {
+    private final LikeRepository likeRepository;
+
+    @Transactional(readOnly = true)
+    public Long get(Long memberId) {
+        LikeEntity likeEntity =
+                likeRepository
+                        .findById(memberId)
+                        .orElseThrow(() -> new MemberNotFoundException(ErrorType.MEMBER_NOT_FOUND));
+        return likeEntity.getCount();
+    }
+}

--- a/api/src/main/java/com/dnd/sbooky/api/like/response/GetLikesResponse.java
+++ b/api/src/main/java/com/dnd/sbooky/api/like/response/GetLikesResponse.java
@@ -1,0 +1,10 @@
+package com.dnd.sbooky.api.like.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "좋아요 수 조회 응답 DTO")
+public record GetLikesResponse(@Schema(description = "좋아요 수") Long count) {
+    public static GetLikesResponse from(Long count) {
+        return new GetLikesResponse(count);
+    }
+}

--- a/api/src/main/java/com/dnd/sbooky/api/member/exception/MemberNotFoundException.java
+++ b/api/src/main/java/com/dnd/sbooky/api/member/exception/MemberNotFoundException.java
@@ -1,4 +1,4 @@
-package com.dnd.sbooky.api.book.exception;
+package com.dnd.sbooky.api.member.exception;
 
 import com.dnd.sbooky.api.support.error.ApiException;
 import com.dnd.sbooky.api.support.error.ErrorType;

--- a/api/src/main/java/com/dnd/sbooky/api/security/SecurityConfig.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/SecurityConfig.java
@@ -37,7 +37,7 @@ public class SecurityConfig {
         "/api-docs/**",
         "/api-docs",
         "/api/auth/reissue",
-        "/api/likes",
+        "/api/likes/**",
     };
 
     private static final String[] openGetApiUrls = {

--- a/core/src/main/java/com/dnd/sbooky/core/like/LikeEntity.java
+++ b/core/src/main/java/com/dnd/sbooky/core/like/LikeEntity.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @Getter
 public class LikeEntity {
     private static final String ENTITY_PREFIX = "likes";
-    public static final long START_COUNT = 0L;
+    private static final long START_COUNT = 0L;
 
     @Id
     @Column(name = ENTITY_PREFIX + "_id")

--- a/core/src/main/java/com/dnd/sbooky/core/like/LikeEntity.java
+++ b/core/src/main/java/com/dnd/sbooky/core/like/LikeEntity.java
@@ -3,12 +3,14 @@ package com.dnd.sbooky.core.like;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "likes")
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class LikeEntity {
     private static final String ENTITY_PREFIX = "likes";
     public static final long START_COUNT = 0L;


### PR DESCRIPTION
## 연관된 이슈

closes #52 

## 작업 내용

방문자용과 호스트용 좋아요 수 조회 API를 각각 구현하였습니다. API를 분리한 이유는 다음과 같습니다.

1. 회원 인식 방식의 차이

방문자용 API는 @PathVariable을 사용하여 특정 회원의 좋아요 수를 조회합니다.
호스트용 API는 엑세스 토큰을 활용하여, 로그인한 사용자의 좋아요 수를 조회합니다.

2. 사용자 유형에 따른 접근 방식 차이

엑세스 토큰을 이용한 요청은 인증된 사용자(즉, 본인)만이 수행할 수 있습니다. 따라서, 해당 API는 로그인한 호스트가 자신의 좋아요 수를 조회하는 데 사용됩니다.
반면, 방문자는 특정 회원의 좋아요 수를 조회할 수 있으나, 인증되지 않은 상태이므로 memberId를 명시적으로 전달해야 합니다.

3. API 사용성 및 명확성 유지

만약 두 API를 통합할 경우, 요청 시 엑세스 토큰과 memberId를 동시에 받을 가능성이 발생합니다.
이로 인해 프론트엔드 측에서 API 사용 방식에 혼란이 생길 수 있으므로, 역할과 사용 목적을 명확히 하기 위해 API를 분리하는 것이 더 적절하다고 판단하였습니다.

## 리뷰 요구사항

> 위와 같이 생각하였는데 승조님 의견이 궁금합니다.