### PR TITLE
아이템 엔티티에 추가된 컬럼을 반영한다. 

### DIFF
--- a/api/src/main/java/com/dnd/sbooky/api/docs/spec/FindItemsApiSpec.java
+++ b/api/src/main/java/com/dnd/sbooky/api/docs/spec/FindItemsApiSpec.java
@@ -1,5 +1,6 @@
 package com.dnd.sbooky.api.docs.spec;
 
+import com.dnd.sbooky.api.item.response.FindEquippedItemsResponse;
 import com.dnd.sbooky.api.item.response.FindItemsResponse;
 import com.dnd.sbooky.api.support.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -14,5 +15,5 @@ public interface FindItemsApiSpec {
     ApiResponse<FindItemsResponse> findMyItems(UserDetails user);
 
     @Operation(summary = "내가 장착한 아이템 조회", description = "내가 장착한 아이템 정보를 조회한다.")
-    ApiResponse<FindItemsResponse> findEquippedItems(UserDetails user);
+    ApiResponse<FindEquippedItemsResponse> findEquippedItems(UserDetails user);
 }

--- a/api/src/main/java/com/dnd/sbooky/api/item/FindEquippedItemUsecase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/FindEquippedItemUsecase.java
@@ -1,7 +1,6 @@
 package com.dnd.sbooky.api.item;
 
 import com.dnd.sbooky.api.item.response.FindEquippedItemsResponse;
-import com.dnd.sbooky.api.item.response.FindItemsResponse;
 import com.dnd.sbooky.core.item.ItemType;
 import com.dnd.sbooky.core.item.MemberItemRepository;
 import java.util.List;

--- a/api/src/main/java/com/dnd/sbooky/api/item/FindEquippedItemUsecase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/FindEquippedItemUsecase.java
@@ -1,5 +1,6 @@
 package com.dnd.sbooky.api.item;
 
+import com.dnd.sbooky.api.item.response.FindEquippedItemsResponse;
 import com.dnd.sbooky.api.item.response.FindItemsResponse;
 import com.dnd.sbooky.core.item.ItemType;
 import com.dnd.sbooky.core.item.MemberItemRepository;
@@ -17,15 +18,15 @@ public class FindEquippedItemUsecase {
     private final MemberItemRepository memberItemRepository;
 
     @Transactional(readOnly = true)
-    public FindItemsResponse findEquippedItems(Long memberId) {
-        Map<ItemType, List<Long>> equippedItems =
+    public FindEquippedItemsResponse findEquippedItems(Long memberId) {
+        Map<ItemType, List<String>> equippedItems =
                 memberItemRepository.findEquippedItemsByMemberId(memberId).stream()
                         .collect(
                                 Collectors.groupingBy(
-                                        findItemDTO -> findItemDTO.itemType(),
+                                        findItemDTO -> findItemDTO.type(),
                                         Collectors.mapping(
-                                                findItemDTO -> findItemDTO.itemId(),
+                                                findItemDTO -> findItemDTO.code(),
                                                 Collectors.toList())));
-        return FindItemsResponse.from(equippedItems);
+        return FindEquippedItemsResponse.from(equippedItems);
     }
 }

--- a/api/src/main/java/com/dnd/sbooky/api/item/FindItemsController.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/FindItemsController.java
@@ -1,6 +1,7 @@
 package com.dnd.sbooky.api.item;
 
 import com.dnd.sbooky.api.docs.spec.FindItemsApiSpec;
+import com.dnd.sbooky.api.item.response.FindEquippedItemsResponse;
 import com.dnd.sbooky.api.item.response.FindItemsResponse;
 import com.dnd.sbooky.api.support.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -26,7 +27,7 @@ public class FindItemsController implements FindItemsApiSpec {
     }
 
     @GetMapping("/items/equipped")
-    public ApiResponse<FindItemsResponse> findEquippedItems(
+    public ApiResponse<FindEquippedItemsResponse> findEquippedItems(
             @Parameter(hidden = true) @AuthenticationPrincipal UserDetails user) {
         return ApiResponse.success(
                 findEquippedItemUsecase.findEquippedItems(extractMemberId(user)));

--- a/api/src/main/java/com/dnd/sbooky/api/item/FindItemsUseCase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/FindItemsUseCase.java
@@ -1,5 +1,6 @@
 package com.dnd.sbooky.api.item;
 
+import com.dnd.sbooky.api.item.response.FindItemResponse;
 import com.dnd.sbooky.api.item.response.FindItemsResponse;
 import com.dnd.sbooky.core.item.ItemType;
 import com.dnd.sbooky.core.item.MemberItemRepository;
@@ -15,16 +16,18 @@ import org.springframework.transaction.annotation.Transactional;
 public class FindItemsUseCase {
 
     private final MemberItemRepository memberItemRepository;
-
     @Transactional(readOnly = true)
     public FindItemsResponse findMyItems(Long memberId) {
-        Map<ItemType, List<Long>> items =
+        Map<ItemType, List<FindItemResponse>> items =
                 memberItemRepository.findItemsByMemberId(memberId).stream()
                         .collect(
                                 Collectors.groupingBy(
-                                        findItemDTO -> findItemDTO.itemType(),
+                                        findItemDTO -> findItemDTO.type(),
                                         Collectors.mapping(
-                                                findItemDTO -> findItemDTO.itemId(),
+                                                findItemDTO ->
+                                                        FindItemResponse.from(
+                                                                findItemDTO.name(),
+                                                                findItemDTO.code()),
                                                 Collectors.toList())));
         return FindItemsResponse.from(items);
     }

--- a/api/src/main/java/com/dnd/sbooky/api/item/FindItemsUseCase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/FindItemsUseCase.java
@@ -16,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class FindItemsUseCase {
 
     private final MemberItemRepository memberItemRepository;
+
     @Transactional(readOnly = true)
     public FindItemsResponse findMyItems(Long memberId) {
         Map<ItemType, List<FindItemResponse>> items =

--- a/api/src/main/java/com/dnd/sbooky/api/item/response/FindEquippedItemsResponse.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/response/FindEquippedItemsResponse.java
@@ -1,0 +1,15 @@
+package com.dnd.sbooky.api.item.response;
+
+import com.dnd.sbooky.core.item.ItemType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.Map;
+
+@Schema(description = "내가 장착한 아이템 조회 응답 DTO")
+public record FindEquippedItemsResponse(
+        @Schema(description = "아이템 타입에 따른 아이템 식별자 모음") Map<ItemType, List<String>> items
+) {
+    public static FindEquippedItemsResponse from(Map<ItemType, List<String>> equippedItems) {
+        return new FindEquippedItemsResponse(equippedItems);
+    }
+}

--- a/api/src/main/java/com/dnd/sbooky/api/item/response/FindEquippedItemsResponse.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/response/FindEquippedItemsResponse.java
@@ -7,8 +7,7 @@ import java.util.Map;
 
 @Schema(description = "내가 장착한 아이템 조회 응답 DTO")
 public record FindEquippedItemsResponse(
-        @Schema(description = "아이템 타입에 따른 아이템 식별자 모음") Map<ItemType, List<String>> items
-) {
+        @Schema(description = "아이템 타입에 따른 아이템 식별자 모음") Map<ItemType, List<String>> items) {
     public static FindEquippedItemsResponse from(Map<ItemType, List<String>> equippedItems) {
         return new FindEquippedItemsResponse(equippedItems);
     }

--- a/api/src/main/java/com/dnd/sbooky/api/item/response/FindItemResponse.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/response/FindItemResponse.java
@@ -3,8 +3,7 @@ package com.dnd.sbooky.api.item.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record FindItemResponse(
-        @Schema(description = "아이템 이름")String name,
-        @Schema(description = "아이템 식별자") String code) {
+        @Schema(description = "아이템 이름") String name, @Schema(description = "아이템 식별자") String code) {
     public static FindItemResponse from(String name, String code) {
         return new FindItemResponse(name, code);
     }

--- a/api/src/main/java/com/dnd/sbooky/api/item/response/FindItemResponse.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/response/FindItemResponse.java
@@ -1,0 +1,11 @@
+package com.dnd.sbooky.api.item.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record FindItemResponse(
+        @Schema(description = "아이템 이름")String name,
+        @Schema(description = "아이템 식별자") String code) {
+    public static FindItemResponse from(String name, String code) {
+        return new FindItemResponse(name, code);
+    }
+}

--- a/api/src/main/java/com/dnd/sbooky/api/item/response/FindItemsResponse.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/response/FindItemsResponse.java
@@ -7,8 +7,7 @@ import java.util.Map;
 
 @Schema(description = "내가 보유한 아이템 조회 응답 DTO")
 public record FindItemsResponse(
-        @Schema(description = "아이템 타입에 따른 아이템 모음")
-                Map<ItemType, List<FindItemResponse>> items) {
+        @Schema(description = "아이템 타입에 따른 아이템 모음") Map<ItemType, List<FindItemResponse>> items) {
     public static FindItemsResponse from(Map<ItemType, List<FindItemResponse>> items) {
         return new FindItemsResponse(items);
     }

--- a/api/src/main/java/com/dnd/sbooky/api/item/response/FindItemsResponse.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/response/FindItemsResponse.java
@@ -7,8 +7,9 @@ import java.util.Map;
 
 @Schema(description = "내가 보유한 아이템 조회 응답 DTO")
 public record FindItemsResponse(
-        @Schema(description = "아이템 타입에 따른 아이템 식별자 모음") Map<ItemType, List<Long>> items) {
-    public static FindItemsResponse from(Map<ItemType, List<Long>> items) {
+        @Schema(description = "아이템 타입에 따른 아이템 모음")
+                Map<ItemType, List<FindItemResponse>> items) {
+    public static FindItemsResponse from(Map<ItemType, List<FindItemResponse>> items) {
         return new FindItemsResponse(items);
     }
 }

--- a/core/src/main/java/com/dnd/sbooky/core/Initializer.java
+++ b/core/src/main/java/com/dnd/sbooky/core/Initializer.java
@@ -24,7 +24,7 @@ public class Initializer {
         MemberEntity memberEntity =
                 memberRepository.save(MemberEntity.newInstance("test1", "test1"));
         likeRepository.save(LikeEntity.newInstance(memberEntity.getId()));
-        itemRepository.save(ItemEntity.newInstance(ItemType.CHARACTER));
-        itemRepository.save(ItemEntity.newInstance(ItemType.CHARACTER));
+        itemRepository.save(ItemEntity.newInstance(ItemType.CHARACTER, "떠돌이 유령", "mummy_ghost"));
+        itemRepository.save(ItemEntity.newInstance(ItemType.CHARACTER, "유령", "basic_ghost"));
     }
 }

--- a/core/src/main/java/com/dnd/sbooky/core/item/ItemEntity.java
+++ b/core/src/main/java/com/dnd/sbooky/core/item/ItemEntity.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 @Entity
@@ -28,11 +29,24 @@ public class ItemEntity extends BaseEntity {
     @Column(name = ENTITY_PREFIX + "_type", nullable = false)
     private ItemType type;
 
-    private ItemEntity(ItemType type) {
+    @Column(name = ENTITY_PREFIX + "_name", nullable = false)
+    private String name;
+
+    @Column(name = ENTITY_PREFIX + "_code", nullable = false)
+    private String code;
+
+    @Builder
+    private ItemEntity(ItemType type, String name, String code) {
         this.type = type;
+        this.name = name;
+        this.code = code;
     }
 
-    public static ItemEntity newInstance(ItemType type) {
-        return new ItemEntity(type);
+    public static ItemEntity newInstance(ItemType type, String name, String code) {
+        return ItemEntity.builder()
+                .type(type)
+                .name(name)
+                .code(code)
+                .build();
     }
 }

--- a/core/src/main/java/com/dnd/sbooky/core/item/ItemEntity.java
+++ b/core/src/main/java/com/dnd/sbooky/core/item/ItemEntity.java
@@ -43,10 +43,6 @@ public class ItemEntity extends BaseEntity {
     }
 
     public static ItemEntity newInstance(ItemType type, String name, String code) {
-        return ItemEntity.builder()
-                .type(type)
-                .name(name)
-                .code(code)
-                .build();
+        return ItemEntity.builder().type(type).name(name).code(code).build();
     }
 }

--- a/core/src/main/java/com/dnd/sbooky/core/item/MemberItemRepositoryImpl.java
+++ b/core/src/main/java/com/dnd/sbooky/core/item/MemberItemRepositoryImpl.java
@@ -16,9 +16,7 @@ public class MemberItemRepositoryImpl implements MemberItemRepositoryCustom {
 
     public List<FindItemDTO> findItemsByMemberId(Long memberId) {
         return queryFactory
-                .select(
-                        Projections.constructor(
-                                FindItemDTO.class, item.code, item.name, item.type))
+                .select(Projections.constructor(FindItemDTO.class, item.code, item.name, item.type))
                 .from(memberItem)
                 .join(memberItem.itemEntity, item)
                 .where(memberItem.memberEntity.id.eq(memberId))
@@ -28,9 +26,7 @@ public class MemberItemRepositoryImpl implements MemberItemRepositoryCustom {
     @Override
     public List<FindItemDTO> findEquippedItemsByMemberId(Long memberId) {
         return queryFactory
-                .select(
-                        Projections.constructor(
-                                FindItemDTO.class, item.code, item.name, item.type))
+                .select(Projections.constructor(FindItemDTO.class, item.code, item.name, item.type))
                 .from(memberItem)
                 .join(memberItem.itemEntity, item)
                 .where(memberItem.memberEntity.id.eq(memberId), isEquipped())

--- a/core/src/main/java/com/dnd/sbooky/core/item/MemberItemRepositoryImpl.java
+++ b/core/src/main/java/com/dnd/sbooky/core/item/MemberItemRepositoryImpl.java
@@ -18,7 +18,7 @@ public class MemberItemRepositoryImpl implements MemberItemRepositoryCustom {
         return queryFactory
                 .select(
                         Projections.constructor(
-                                FindItemDTO.class, memberItem.itemEntity.id, item.type))
+                                FindItemDTO.class, item.code, item.name, item.type))
                 .from(memberItem)
                 .join(memberItem.itemEntity, item)
                 .where(memberItem.memberEntity.id.eq(memberId))
@@ -30,7 +30,7 @@ public class MemberItemRepositoryImpl implements MemberItemRepositoryCustom {
         return queryFactory
                 .select(
                         Projections.constructor(
-                                FindItemDTO.class, memberItem.itemEntity.id, item.type))
+                                FindItemDTO.class, item.code, item.name, item.type))
                 .from(memberItem)
                 .join(memberItem.itemEntity, item)
                 .where(memberItem.memberEntity.id.eq(memberId), isEquipped())

--- a/core/src/main/java/com/dnd/sbooky/core/item/dto/FindItemDTO.java
+++ b/core/src/main/java/com/dnd/sbooky/core/item/dto/FindItemDTO.java
@@ -2,4 +2,4 @@ package com.dnd.sbooky.core.item.dto;
 
 import com.dnd.sbooky.core.item.ItemType;
 
-public record FindItemDTO(Long itemId, ItemType itemType) {}
+public record FindItemDTO(String code, String name, ItemType type) {}


### PR DESCRIPTION
## 연관된 이슈

closes #70 

## 작업 내용

- 아이템 엔티티에 식별자와 이름을 추가하였습니다.
- 내가 착용한 아이템 조회 API 응답값과 내가 가지고 있는 아이템 조회 API 응답값을 수정하였습니다.

내가 착용한 아이템 조회)
![스크린샷 2025-02-05 오후 9 46 47](https://github.com/user-attachments/assets/4562fcd0-b823-4608-b434-5bf5aeb459ba)

내가 가지고 있는 아이템 조회)
![스크린샷 2025-02-05 오후 9 46 59](https://github.com/user-attachments/assets/17ca7730-4359-42ae-bbf9-d77e95c15684)


## 리뷰 요구사항

