### PR TITLE
책 평가 리스트를 조회한다.

### DIFF
--- a/api/src/main/java/com/dnd/sbooky/api/book/exception/BookReadStatusException.java
+++ b/api/src/main/java/com/dnd/sbooky/api/book/exception/BookReadStatusException.java
@@ -1,0 +1,11 @@
+package com.dnd.sbooky.api.book.exception;
+
+import com.dnd.sbooky.api.support.error.ApiException;
+import com.dnd.sbooky.api.support.error.ErrorType;
+
+public class BookReadStatusException extends ApiException {
+
+    public BookReadStatusException(ErrorType errorType) {
+        super(errorType);
+    }
+}

--- a/api/src/main/java/com/dnd/sbooky/api/docs/spec/GetEvaluationApiSpec.java
+++ b/api/src/main/java/com/dnd/sbooky/api/docs/spec/GetEvaluationApiSpec.java
@@ -1,0 +1,15 @@
+package com.dnd.sbooky.api.docs.spec;
+
+import com.dnd.sbooky.api.evaluation.response.GetEvaluationResponse;
+import com.dnd.sbooky.api.support.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@Tag(name = "[Evaluation API]", description = "평가에 관련된 API")
+public interface GetEvaluationApiSpec {
+
+    @Operation(summary = "평가 리스트 조회", description = "평가 리스트를 조회한다.")
+    ApiResponse<List<GetEvaluationResponse>> getEvaluation(Long memberBookId, UserDetails user);
+}

--- a/api/src/main/java/com/dnd/sbooky/api/evaluation/GetEvaluationController.java
+++ b/api/src/main/java/com/dnd/sbooky/api/evaluation/GetEvaluationController.java
@@ -1,0 +1,35 @@
+package com.dnd.sbooky.api.evaluation;
+
+import com.dnd.sbooky.api.docs.spec.GetEvaluationApiSpec;
+import com.dnd.sbooky.api.evaluation.response.GetEvaluationResponse;
+import com.dnd.sbooky.api.support.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Parameter;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class GetEvaluationController implements GetEvaluationApiSpec {
+
+    private final GetEvaluationUseCase getEvaluationUseCase;
+
+    @GetMapping("/books/{memberBookId}/evaluation")
+    public ApiResponse<List<GetEvaluationResponse>> getEvaluation(
+            @PathVariable Long memberBookId,
+            @Parameter(hidden = true) @AuthenticationPrincipal UserDetails user) {
+
+        Long memberId = getMemberId(user);
+        return ApiResponse.success(getEvaluationUseCase.get(memberId, memberBookId));
+    }
+
+    private Long getMemberId(UserDetails user) {
+        return Long.valueOf(user.getUsername());
+    }
+}

--- a/api/src/main/java/com/dnd/sbooky/api/evaluation/GetEvaluationUseCase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/evaluation/GetEvaluationUseCase.java
@@ -1,0 +1,44 @@
+package com.dnd.sbooky.api.evaluation;
+
+import com.dnd.sbooky.api.book.exception.BookForbiddenException;
+import com.dnd.sbooky.api.book.exception.BookNotFoundException;
+import com.dnd.sbooky.api.book.exception.BookReadStatusException;
+import com.dnd.sbooky.api.evaluation.response.GetEvaluationResponse;
+import com.dnd.sbooky.api.support.error.ErrorType;
+import com.dnd.sbooky.core.book.MemberBookEntity;
+import com.dnd.sbooky.core.book.MemberBookRepository;
+import com.dnd.sbooky.core.book.ReadStatus;
+import com.dnd.sbooky.core.evaluation.EvaluationRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class GetEvaluationUseCase {
+
+    private final EvaluationRepository evaluationRepository;
+    private final MemberBookRepository memberBookRepository;
+
+    @Transactional(readOnly = true)
+    public List<GetEvaluationResponse> get(Long memberId, Long memberBookId) {
+
+        MemberBookEntity memberBook =
+                memberBookRepository
+                        .findById(memberBookId)
+                        .orElseThrow(() -> new BookNotFoundException(ErrorType.BOOK_NOT_FOUND));
+
+        if (!memberBook.isSameMember(memberId)) {
+            throw new BookForbiddenException(ErrorType.BOOK_ACCESS_FORBIDDEN);
+        }
+
+        if (memberBook.getReadStatus() != ReadStatus.COMPLETED) {
+            throw new BookReadStatusException(ErrorType.BOOK_READ_STATUS_NOT_COMPLETED);
+        }
+
+        return evaluationRepository.findAll().stream()
+                .map(evaluation -> GetEvaluationResponse.of(evaluation.getKeyword()))
+                .toList();
+    }
+}

--- a/api/src/main/java/com/dnd/sbooky/api/evaluation/response/GetEvaluationResponse.java
+++ b/api/src/main/java/com/dnd/sbooky/api/evaluation/response/GetEvaluationResponse.java
@@ -1,0 +1,16 @@
+package com.dnd.sbooky.api.evaluation.response;
+
+import com.dnd.sbooky.core.evaluation.EvaluationKeyword;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "평가 리스트 조회 응답")
+public record GetEvaluationResponse(
+        @Schema(description = "평가 ID") Long evaluationId,
+        @Schema(description = "평가 타입") String type,
+        @Schema(description = "평가 키워드") String keyword) {
+
+    public static GetEvaluationResponse of(EvaluationKeyword keyword) {
+        return new GetEvaluationResponse(
+                keyword.getId(), keyword.getType().getDescription(), keyword.getDescription());
+    }
+}

--- a/api/src/main/java/com/dnd/sbooky/api/support/error/ErrorCode.java
+++ b/api/src/main/java/com/dnd/sbooky/api/support/error/ErrorCode.java
@@ -7,6 +7,7 @@ public enum ErrorCode {
     E400,
     E403,
     E404,
+    BOOK_400_1,
     BOOK_403,
     BOOK_404,
     MEMBER_404,

--- a/api/src/main/java/com/dnd/sbooky/api/support/error/ErrorType.java
+++ b/api/src/main/java/com/dnd/sbooky/api/support/error/ErrorType.java
@@ -1,6 +1,10 @@
 package com.dnd.sbooky.api.support.error;
 
-import static org.springframework.http.HttpStatus.*;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 import lombok.Getter;
 import org.springframework.boot.logging.LogLevel;
@@ -27,6 +31,8 @@ public enum ErrorType {
     // Book Error
     BOOK_ACCESS_FORBIDDEN(FORBIDDEN, ErrorCode.BOOK_403, "Book access is forbidden.", LogLevel.INFO),
     BOOK_NOT_FOUND(NOT_FOUND, ErrorCode.BOOK_404, "Book was not found.", LogLevel.INFO),
+    BOOK_READ_STATUS_NOT_COMPLETED(
+            BAD_REQUEST, ErrorCode.BOOK_400_1, "Book read status is not completed.", LogLevel.INFO),
 
     // Item Error
     ITEM_NOT_FOUND(NOT_FOUND, ErrorCode.ITEM_404, "Item was not found.", LogLevel.INFO);

--- a/core/src/main/java/com/dnd/sbooky/core/Initializer.java
+++ b/core/src/main/java/com/dnd/sbooky/core/Initializer.java
@@ -1,6 +1,6 @@
 package com.dnd.sbooky.core;
 
-import com.dnd.sbooky.core.evaluation.Evaluation;
+import com.dnd.sbooky.core.evaluation.EvaluationEntity;
 import com.dnd.sbooky.core.evaluation.EvaluationKeyword;
 import com.dnd.sbooky.core.evaluation.EvaluationRepository;
 import com.dnd.sbooky.core.item.ItemEntity;
@@ -32,6 +32,6 @@ public class Initializer {
         itemRepository.save(ItemEntity.newInstance(ItemType.CHARACTER, "유령", "basic_ghost"));
 
         Arrays.stream(EvaluationKeyword.values())
-                .forEach(keyword -> evaluationRepository.save(Evaluation.newInstance(keyword)));
+                .forEach(keyword -> evaluationRepository.save(EvaluationEntity.newInstance(keyword)));
     }
 }

--- a/core/src/main/java/com/dnd/sbooky/core/Initializer.java
+++ b/core/src/main/java/com/dnd/sbooky/core/Initializer.java
@@ -1,5 +1,8 @@
 package com.dnd.sbooky.core;
 
+import com.dnd.sbooky.core.evaluation.Evaluation;
+import com.dnd.sbooky.core.evaluation.EvaluationKeyword;
+import com.dnd.sbooky.core.evaluation.EvaluationRepository;
 import com.dnd.sbooky.core.item.ItemEntity;
 import com.dnd.sbooky.core.item.ItemRepository;
 import com.dnd.sbooky.core.item.ItemType;
@@ -8,6 +11,7 @@ import com.dnd.sbooky.core.like.LikeRepository;
 import com.dnd.sbooky.core.member.MemberEntity;
 import com.dnd.sbooky.core.member.MemberRepository;
 import jakarta.annotation.PostConstruct;
+import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -18,6 +22,7 @@ public class Initializer {
     private final MemberRepository memberRepository;
     private final LikeRepository likeRepository;
     private final ItemRepository itemRepository;
+    private final EvaluationRepository evaluationRepository;
 
     @PostConstruct
     public void init() {
@@ -25,5 +30,8 @@ public class Initializer {
         likeRepository.save(LikeEntity.newInstance(memberEntity.getId()));
         itemRepository.save(ItemEntity.newInstance(ItemType.CHARACTER, "떠돌이 유령", "mummy_ghost"));
         itemRepository.save(ItemEntity.newInstance(ItemType.CHARACTER, "유령", "basic_ghost"));
+
+        Arrays.stream(EvaluationKeyword.values())
+                .forEach(keyword -> evaluationRepository.save(Evaluation.newInstance(keyword)));
     }
 }

--- a/core/src/main/java/com/dnd/sbooky/core/evaluation/Evaluation.java
+++ b/core/src/main/java/com/dnd/sbooky/core/evaluation/Evaluation.java
@@ -1,0 +1,54 @@
+package com.dnd.sbooky.core.evaluation;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "evaluation")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Evaluation {
+
+    private static final String ENTITY_PREFIX = "evaluation";
+
+    @Id
+    @Column(name = ENTITY_PREFIX + "_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = ENTITY_PREFIX + "_type", nullable = false)
+    private EvaluationType type;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = ENTITY_PREFIX + "_keyword", nullable = false)
+    private EvaluationKeyword keyword;
+
+    private Evaluation(Long id, EvaluationType type, EvaluationKeyword keyword) {
+        precondition(id, type, keyword);
+        this.id = id;
+        this.type = type;
+        this.keyword = keyword;
+    }
+
+    public static Evaluation newInstance(EvaluationKeyword keyword) {
+        return new Evaluation(keyword.getId(), keyword.getType(), keyword);
+    }
+
+    private static void precondition(Long id, EvaluationType type, EvaluationKeyword keyword) {
+        if (type != keyword.getType()) {
+            throw new IllegalStateException("Both type and keyword must be the same.");
+        }
+
+        if (!type.isInRange(id)) {
+            throw new IllegalArgumentException("Id is out of range.");
+        }
+    }
+
+}

--- a/core/src/main/java/com/dnd/sbooky/core/evaluation/Evaluation.java
+++ b/core/src/main/java/com/dnd/sbooky/core/evaluation/Evaluation.java
@@ -50,5 +50,4 @@ public class Evaluation {
             throw new IllegalArgumentException("Id is out of range.");
         }
     }
-
 }

--- a/core/src/main/java/com/dnd/sbooky/core/evaluation/EvaluationEntity.java
+++ b/core/src/main/java/com/dnd/sbooky/core/evaluation/EvaluationEntity.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "evaluation")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Evaluation {
+public class EvaluationEntity {
 
     private static final String ENTITY_PREFIX = "evaluation";
 
@@ -30,15 +30,15 @@ public class Evaluation {
     @Column(name = ENTITY_PREFIX + "_keyword", nullable = false)
     private EvaluationKeyword keyword;
 
-    private Evaluation(Long id, EvaluationType type, EvaluationKeyword keyword) {
+    private EvaluationEntity(Long id, EvaluationType type, EvaluationKeyword keyword) {
         precondition(id, type, keyword);
         this.id = id;
         this.type = type;
         this.keyword = keyword;
     }
 
-    public static Evaluation newInstance(EvaluationKeyword keyword) {
-        return new Evaluation(keyword.getId(), keyword.getType(), keyword);
+    public static EvaluationEntity newInstance(EvaluationKeyword keyword) {
+        return new EvaluationEntity(keyword.getId(), keyword.getType(), keyword);
     }
 
     private static void precondition(Long id, EvaluationType type, EvaluationKeyword keyword) {

--- a/core/src/main/java/com/dnd/sbooky/core/evaluation/EvaluationKeyword.java
+++ b/core/src/main/java/com/dnd/sbooky/core/evaluation/EvaluationKeyword.java
@@ -1,0 +1,32 @@
+package com.dnd.sbooky.core.evaluation;
+
+import lombok.Getter;
+
+
+@Getter
+public enum EvaluationKeyword {
+    IMMERSIVE(101L, EvaluationType.GOOD, "몰입감 높은"),
+    EMOTIONAL(102L, EvaluationType.GOOD, "감동적인"),
+    INFORMATIVE(103L, EvaluationType.GOOD, "유익한"),
+    BEAUTIFUL_SENTENCE(104L, EvaluationType.GOOD, "문장이 아름다운"),
+    EASY_TO_READ(105L, EvaluationType.GOOD, "읽기 부담없는"),
+    LONG_LASTING_AFTERGLOW(106L, EvaluationType.GOOD, "여운이 오래가는"),
+    RECOMMENDABLE(107L, EvaluationType.GOOD, "추천하고 싶은"),
+    KNOWLEDGEABLE(108L, EvaluationType.GOOD, "새로운 지식을 주는"),
+
+    BORING(201L, EvaluationType.SHAME, "지루한"),
+    DISAPPOINTING(202L, EvaluationType.SHAME, "기대보다 아쉬운"),
+    LACK_OF_COHERENCE(203L, EvaluationType.SHAME, "개연성이 부족한"),
+    DIFFICULT_SENTENCE(204L, EvaluationType.SHAME, "문장이 난해한"),
+    UNSATISFYING_ENDING(205L, EvaluationType.SHAME, "결말이 아쉬운");
+
+    private final Long id;
+    private final EvaluationType type;
+    private final String description;
+
+    EvaluationKeyword(Long id, EvaluationType type, String description) {
+        this.id = id;
+        this.type = type;
+        this.description = description;
+    }
+}

--- a/core/src/main/java/com/dnd/sbooky/core/evaluation/EvaluationKeyword.java
+++ b/core/src/main/java/com/dnd/sbooky/core/evaluation/EvaluationKeyword.java
@@ -2,10 +2,8 @@ package com.dnd.sbooky.core.evaluation;
 
 import lombok.Getter;
 
-
 @Getter
 public enum EvaluationKeyword {
-
     IMMERSIVE(101L, EvaluationType.GOOD, "몰입감 높은"),
     EMOTIONAL(102L, EvaluationType.GOOD, "감동적인"),
     INFORMATIVE(103L, EvaluationType.GOOD, "유익한"),

--- a/core/src/main/java/com/dnd/sbooky/core/evaluation/EvaluationKeyword.java
+++ b/core/src/main/java/com/dnd/sbooky/core/evaluation/EvaluationKeyword.java
@@ -5,20 +5,22 @@ import lombok.Getter;
 
 @Getter
 public enum EvaluationKeyword {
+
     IMMERSIVE(101L, EvaluationType.GOOD, "몰입감 높은"),
     EMOTIONAL(102L, EvaluationType.GOOD, "감동적인"),
     INFORMATIVE(103L, EvaluationType.GOOD, "유익한"),
-    BEAUTIFUL_SENTENCE(104L, EvaluationType.GOOD, "문장이 아름다운"),
-    EASY_TO_READ(105L, EvaluationType.GOOD, "읽기 부담없는"),
-    LONG_LASTING_AFTERGLOW(106L, EvaluationType.GOOD, "여운이 오래가는"),
-    RECOMMENDABLE(107L, EvaluationType.GOOD, "추천하고 싶은"),
-    KNOWLEDGEABLE(108L, EvaluationType.GOOD, "새로운 지식을 주는"),
+    RECOMMENDABLE(104L, EvaluationType.GOOD, "추천하고 싶은"),
+    STIMULATE_DOPAMINE(105L, EvaluationType.GOOD, "도파민을 자극하는"),
+    BEAUTIFUL_SENTENCE(106L, EvaluationType.GOOD, "문장이 아름다운"),
+    KNOWLEDGEABLE(107L, EvaluationType.GOOD, "새로운 지식을 주는"),
+    EASY_TO_READ(108L, EvaluationType.GOOD, "읽기 부담없는"),
+    LONG_LASTING_AFTERGLOW(109L, EvaluationType.GOOD, "여운이 오래가는"),
 
     BORING(201L, EvaluationType.SHAME, "지루한"),
     DISAPPOINTING(202L, EvaluationType.SHAME, "기대보다 아쉬운"),
-    LACK_OF_COHERENCE(203L, EvaluationType.SHAME, "개연성이 부족한"),
-    DIFFICULT_SENTENCE(204L, EvaluationType.SHAME, "문장이 난해한"),
-    UNSATISFYING_ENDING(205L, EvaluationType.SHAME, "결말이 아쉬운");
+    DIFFICULT_SENTENCE(203L, EvaluationType.SHAME, "문장이 난해한"),
+    LACK_OF_COHERENCE(204L, EvaluationType.SHAME, "개연성이 부족한"),
+    THREADBARE(205L, EvaluationType.SHAME, "진부한");
 
     private final Long id;
     private final EvaluationType type;

--- a/core/src/main/java/com/dnd/sbooky/core/evaluation/EvaluationRepository.java
+++ b/core/src/main/java/com/dnd/sbooky/core/evaluation/EvaluationRepository.java
@@ -1,0 +1,5 @@
+package com.dnd.sbooky.core.evaluation;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EvaluationRepository extends JpaRepository<Evaluation, Long> {}

--- a/core/src/main/java/com/dnd/sbooky/core/evaluation/EvaluationRepository.java
+++ b/core/src/main/java/com/dnd/sbooky/core/evaluation/EvaluationRepository.java
@@ -2,4 +2,4 @@ package com.dnd.sbooky.core.evaluation;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface EvaluationRepository extends JpaRepository<Evaluation, Long> {}
+public interface EvaluationRepository extends JpaRepository<EvaluationEntity, Long> {}

--- a/core/src/main/java/com/dnd/sbooky/core/evaluation/EvaluationType.java
+++ b/core/src/main/java/com/dnd/sbooky/core/evaluation/EvaluationType.java
@@ -1,0 +1,21 @@
+package com.dnd.sbooky.core.evaluation;
+
+import lombok.Getter;
+
+@Getter
+public enum EvaluationType {
+    GOOD(100L, "좋았어요"),
+    SHAME(200L, "아쉬웠어요");
+
+    private final Long idPrefix;
+    private final String description;
+
+    EvaluationType(Long idPrefix, String description) {
+        this.idPrefix = idPrefix;
+        this.description = description;
+    }
+
+    public boolean isInRange(Long id) {
+        return id >= idPrefix && id < idPrefix + 100L;
+    }
+}


### PR DESCRIPTION
## 연관된 이슈

resolves #76 

## 작업 내용

- 평가 Entity 및 JPA 세팅
- 평가 리스트 조회 API 구성 
- Initializer 에서 평가 항목 추가 작업 

## 리뷰 요구사항

확장성을 고려해서 EvaluationType, EvaluationKeyword을 구성했는데 괜찮을까요? 

### EvaluationType

- 좋았어요: GOOD, 100번대 아이디 사용
- 아쉬웠어요: SHAME, 200번대 아이디 사용

이렇게 구성한 이유는 새로운 키워드가 등장에 대해서 유연하게 대처하게 하도록 하고싶었어요. 

> _ex. 별로에요: BAD 인 경우엔 300번대 아이디 사용_


### EvaluationKeyword

DB 테이블처럼 구조가 잡혀있는 형태에요!
만약에 `MemberBookEntity` 내부에 배열 형태의 컬럼(ex. [101, 103, 106, 204])이 존재한다면 변환하기 편할 것 같다고 생각이 들었어요. 