### PR TITLE
책 평가 리스트 조회 응답 구조를 수정한다.

### DIFF
--- a/api/src/main/java/com/dnd/sbooky/api/docs/spec/RegisterEvaluationApiSpec.java
+++ b/api/src/main/java/com/dnd/sbooky/api/docs/spec/RegisterEvaluationApiSpec.java
@@ -1,0 +1,15 @@
+package com.dnd.sbooky.api.docs.spec;
+
+import com.dnd.sbooky.api.evaluation.request.RegisterEvaluationRequest;
+import com.dnd.sbooky.api.support.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@Tag(name = "[Evaluation API]", description = "평가에 관련된 API")
+public interface RegisterEvaluationApiSpec {
+
+    @Operation(summary = "평가 등록", description = "완독한 책에 대해 평가를 등록한다.")
+    ApiResponse<?> registerEvaluation(
+            Long memberBookId, RegisterEvaluationRequest request, UserDetails userDetails);
+}

--- a/api/src/main/java/com/dnd/sbooky/api/evaluation/GetEvaluationUseCase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/evaluation/GetEvaluationUseCase.java
@@ -37,8 +37,8 @@ public class GetEvaluationUseCase {
             throw new BookReadStatusException(ErrorType.BOOK_READ_STATUS_NOT_COMPLETED);
         }
 
-        return evaluationRepository.findAll().stream()
-                .map(evaluation -> GetEvaluationResponse.of(evaluation.getKeyword()))
+        return evaluationRepository.findAllWithSelectedByMemberBookId(memberBookId).stream()
+                .map(GetEvaluationResponse::of)
                 .toList();
     }
 }

--- a/api/src/main/java/com/dnd/sbooky/api/evaluation/RegisterEvaluationController.java
+++ b/api/src/main/java/com/dnd/sbooky/api/evaluation/RegisterEvaluationController.java
@@ -1,5 +1,6 @@
 package com.dnd.sbooky.api.evaluation;
 
+import com.dnd.sbooky.api.docs.spec.RegisterEvaluationApiSpec;
 import com.dnd.sbooky.api.evaluation.request.RegisterEvaluationRequest;
 import com.dnd.sbooky.api.support.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -16,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor
-public class RegisterEvaluationController {
+public class RegisterEvaluationController implements RegisterEvaluationApiSpec {
 
     private final RegisterEvaluationUseCase registerEvaluationUseCase;
 

--- a/api/src/main/java/com/dnd/sbooky/api/evaluation/RegisterEvaluationController.java
+++ b/api/src/main/java/com/dnd/sbooky/api/evaluation/RegisterEvaluationController.java
@@ -6,12 +6,14 @@ import com.dnd.sbooky.api.support.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -22,6 +24,7 @@ public class RegisterEvaluationController implements RegisterEvaluationApiSpec {
     private final RegisterEvaluationUseCase registerEvaluationUseCase;
 
     @PutMapping("/books/{memberBookId}/evaluation")
+    @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<?> registerEvaluation(
             @PathVariable Long memberBookId,
             @Valid @RequestBody RegisterEvaluationRequest request,

--- a/api/src/main/java/com/dnd/sbooky/api/evaluation/RegisterEvaluationController.java
+++ b/api/src/main/java/com/dnd/sbooky/api/evaluation/RegisterEvaluationController.java
@@ -1,0 +1,39 @@
+package com.dnd.sbooky.api.evaluation;
+
+import com.dnd.sbooky.api.evaluation.request.RegisterEvaluationRequest;
+import com.dnd.sbooky.api.support.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class RegisterEvaluationController {
+
+    private final RegisterEvaluationUseCase registerEvaluationUseCase;
+
+    @PostMapping("/books/{memberBookId}/evaluation")
+    public ApiResponse<?> registerEvaluation(
+            @PathVariable Long memberBookId,
+            @Valid @RequestBody RegisterEvaluationRequest request,
+            @Parameter(hidden = true) @AuthenticationPrincipal UserDetails user) {
+
+        registerEvaluationUseCase.register(memberBookId, extractMemberId(user), request);
+        return ApiResponse.success();
+    }
+
+
+    private Long extractMemberId(UserDetails user) {
+        return Long.valueOf(user.getUsername());
+    }
+
+}

--- a/api/src/main/java/com/dnd/sbooky/api/evaluation/RegisterEvaluationController.java
+++ b/api/src/main/java/com/dnd/sbooky/api/evaluation/RegisterEvaluationController.java
@@ -13,7 +13,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor
@@ -31,9 +30,7 @@ public class RegisterEvaluationController {
         return ApiResponse.success();
     }
 
-
     private Long extractMemberId(UserDetails user) {
         return Long.valueOf(user.getUsername());
     }
-
 }

--- a/api/src/main/java/com/dnd/sbooky/api/evaluation/RegisterEvaluationController.java
+++ b/api/src/main/java/com/dnd/sbooky/api/evaluation/RegisterEvaluationController.java
@@ -9,7 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,7 +21,7 @@ public class RegisterEvaluationController implements RegisterEvaluationApiSpec {
 
     private final RegisterEvaluationUseCase registerEvaluationUseCase;
 
-    @PostMapping("/books/{memberBookId}/evaluation")
+    @PutMapping("/books/{memberBookId}/evaluation")
     public ApiResponse<?> registerEvaluation(
             @PathVariable Long memberBookId,
             @Valid @RequestBody RegisterEvaluationRequest request,

--- a/api/src/main/java/com/dnd/sbooky/api/evaluation/RegisterEvaluationUseCase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/evaluation/RegisterEvaluationUseCase.java
@@ -1,13 +1,17 @@
 package com.dnd.sbooky.api.evaluation;
 
+import com.dnd.sbooky.api.book.exception.BookForbiddenException;
 import com.dnd.sbooky.api.book.exception.BookNotFoundException;
+import com.dnd.sbooky.api.evaluation.exception.EvaluationNotFoundException;
 import com.dnd.sbooky.api.evaluation.request.RegisterEvaluationRequest;
 import com.dnd.sbooky.api.support.error.ErrorType;
 import com.dnd.sbooky.core.book.MemberBookEntity;
 import com.dnd.sbooky.core.book.MemberBookRepository;
 import com.dnd.sbooky.core.evaluation.BookEvaluationEntity;
 import com.dnd.sbooky.core.evaluation.BookEvaluationRepository;
+import com.dnd.sbooky.core.evaluation.EvaluationEntity;
 import com.dnd.sbooky.core.evaluation.EvaluationRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,16 +27,43 @@ public class RegisterEvaluationUseCase {
 
     public void register(Long memberBookId, Long memberId, RegisterEvaluationRequest request) {
 
+        MemberBookEntity memberBook = validateAndGetMemberBook(memberBookId, memberId);
+
+        bookEvaluationRepository.deleteAllByMemberBookId(memberBookId);
+
+        List<EvaluationEntity> evaluations = getValidatedEvaluations(request.keywordIds());
+
+        List<BookEvaluationEntity> bookEvaluations =
+                evaluations.stream()
+                        .map(evaluation -> BookEvaluationEntity.newInstance(memberBook, evaluation))
+                        .toList();
+
+        bookEvaluationRepository.saveAll(bookEvaluations);
+    }
+
+    private MemberBookEntity validateAndGetMemberBook(Long memberBookId, Long memberId) {
         MemberBookEntity memberBook =
                 memberBookRepository
                         .findById(memberBookId)
                         .orElseThrow(() -> new BookNotFoundException(ErrorType.BOOK_NOT_FOUND));
 
-        request.keywordIds().forEach(keywordId -> {
-            EvaluationevaluationRepository.findById(keywordId)
-                    .orElseThrow(() -> new EvaluationKeywordNotFoundException(ErrorType.EVALUATION_KEYWORD_NOT_FOUND));
-            bookEvaluationRepository.save(BookEvaluationEntity.newInstance(memberBook, ))
-        });
+        if (!memberBook.isSameMember(memberId)) {
+            throw new BookForbiddenException(ErrorType.BOOK_ACCESS_FORBIDDEN);
+        }
 
+        return memberBook;
+    }
+
+    private List<EvaluationEntity> getValidatedEvaluations(List<Long> keywordIds) {
+        return keywordIds.stream()
+                .map(
+                        id ->
+                                evaluationRepository
+                                        .findById(id)
+                                        .orElseThrow(
+                                                () ->
+                                                        new EvaluationNotFoundException(
+                                                                ErrorType.EVALUATION_KEYWORD_NOT_FOUND)))
+                .toList();
     }
 }

--- a/api/src/main/java/com/dnd/sbooky/api/evaluation/RegisterEvaluationUseCase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/evaluation/RegisterEvaluationUseCase.java
@@ -2,11 +2,13 @@ package com.dnd.sbooky.api.evaluation;
 
 import com.dnd.sbooky.api.book.exception.BookForbiddenException;
 import com.dnd.sbooky.api.book.exception.BookNotFoundException;
+import com.dnd.sbooky.api.book.exception.BookReadStatusException;
 import com.dnd.sbooky.api.evaluation.exception.EvaluationNotFoundException;
 import com.dnd.sbooky.api.evaluation.request.RegisterEvaluationRequest;
 import com.dnd.sbooky.api.support.error.ErrorType;
 import com.dnd.sbooky.core.book.MemberBookEntity;
 import com.dnd.sbooky.core.book.MemberBookRepository;
+import com.dnd.sbooky.core.book.ReadStatus;
 import com.dnd.sbooky.core.evaluation.BookEvaluationEntity;
 import com.dnd.sbooky.core.evaluation.BookEvaluationRepository;
 import com.dnd.sbooky.core.evaluation.EvaluationEntity;
@@ -49,6 +51,10 @@ public class RegisterEvaluationUseCase {
 
         if (!memberBook.isSameMember(memberId)) {
             throw new BookForbiddenException(ErrorType.BOOK_ACCESS_FORBIDDEN);
+        }
+
+        if (memberBook.getReadStatus() != ReadStatus.COMPLETED) {
+            throw new BookReadStatusException(ErrorType.BOOK_READ_STATUS_NOT_COMPLETED);
         }
 
         return memberBook;

--- a/api/src/main/java/com/dnd/sbooky/api/evaluation/RegisterEvaluationUseCase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/evaluation/RegisterEvaluationUseCase.java
@@ -1,0 +1,38 @@
+package com.dnd.sbooky.api.evaluation;
+
+import com.dnd.sbooky.api.book.exception.BookNotFoundException;
+import com.dnd.sbooky.api.evaluation.request.RegisterEvaluationRequest;
+import com.dnd.sbooky.api.support.error.ErrorType;
+import com.dnd.sbooky.core.book.MemberBookEntity;
+import com.dnd.sbooky.core.book.MemberBookRepository;
+import com.dnd.sbooky.core.evaluation.BookEvaluationEntity;
+import com.dnd.sbooky.core.evaluation.BookEvaluationRepository;
+import com.dnd.sbooky.core.evaluation.EvaluationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class RegisterEvaluationUseCase {
+
+    private final MemberBookRepository memberBookRepository;
+    private final BookEvaluationRepository bookEvaluationRepository;
+    private final EvaluationRepository evaluationRepository;
+
+    public void register(Long memberBookId, Long memberId, RegisterEvaluationRequest request) {
+
+        MemberBookEntity memberBook =
+                memberBookRepository
+                        .findById(memberBookId)
+                        .orElseThrow(() -> new BookNotFoundException(ErrorType.BOOK_NOT_FOUND));
+
+        request.keywordIds().forEach(keywordId -> {
+            EvaluationevaluationRepository.findById(keywordId)
+                    .orElseThrow(() -> new EvaluationKeywordNotFoundException(ErrorType.EVALUATION_KEYWORD_NOT_FOUND));
+            bookEvaluationRepository.save(BookEvaluationEntity.newInstance(memberBook, ))
+        });
+
+    }
+}

--- a/api/src/main/java/com/dnd/sbooky/api/evaluation/exception/EvaluationNotFoundException.java
+++ b/api/src/main/java/com/dnd/sbooky/api/evaluation/exception/EvaluationNotFoundException.java
@@ -1,0 +1,11 @@
+package com.dnd.sbooky.api.evaluation.exception;
+
+import com.dnd.sbooky.api.support.error.ApiException;
+import com.dnd.sbooky.api.support.error.ErrorType;
+
+public class EvaluationNotFoundException extends ApiException {
+
+    public EvaluationNotFoundException(ErrorType errorType) {
+        super(errorType);
+    }
+}

--- a/api/src/main/java/com/dnd/sbooky/api/evaluation/request/RegisterEvaluationRequest.java
+++ b/api/src/main/java/com/dnd/sbooky/api/evaluation/request/RegisterEvaluationRequest.java
@@ -8,9 +8,4 @@ import java.util.List;
 @Schema(description = "평가 등록 요청 DTO")
 public record RegisterEvaluationRequest(
         @Schema(description = "평가 키워드 아이디 리스트")
-        @NotNull
-        @Size(min = 1, max = 6, message = "평가 키워드는 1개 이상 6개 이하로 등록해주세요.")
-        List<Long> keywordIds
-) {
-
-}
+                @NotNull @Size(min = 1, max = 6, message = "평가 키워드는 1개 이상 6개 이하로 등록해주세요.") List<Long> keywordIds) {}

--- a/api/src/main/java/com/dnd/sbooky/api/evaluation/request/RegisterEvaluationRequest.java
+++ b/api/src/main/java/com/dnd/sbooky/api/evaluation/request/RegisterEvaluationRequest.java
@@ -1,0 +1,16 @@
+package com.dnd.sbooky.api.evaluation.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+@Schema(description = "평가 등록 요청 DTO")
+public record RegisterEvaluationRequest(
+        @Schema(description = "평가 키워드 아이디 리스트")
+        @NotNull
+        @Size(min = 1, max = 6, message = "평가 키워드는 1개 이상 6개 이하로 등록해주세요.")
+        List<Long> keywordIds
+) {
+
+}

--- a/api/src/main/java/com/dnd/sbooky/api/evaluation/response/GetEvaluationResponse.java
+++ b/api/src/main/java/com/dnd/sbooky/api/evaluation/response/GetEvaluationResponse.java
@@ -1,16 +1,20 @@
 package com.dnd.sbooky.api.evaluation.response;
 
-import com.dnd.sbooky.core.evaluation.EvaluationKeyword;
+import com.dnd.sbooky.core.evaluation.dto.GetEvaluationDTO;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "평가 리스트 조회 응답")
 public record GetEvaluationResponse(
         @Schema(description = "평가 ID") Long evaluationId,
         @Schema(description = "평가 타입") String type,
-        @Schema(description = "평가 키워드") String keyword) {
+        @Schema(description = "평가 키워드") String keyword,
+        @Schema(description = "선택 여부") boolean isSelected) {
 
-    public static GetEvaluationResponse of(EvaluationKeyword keyword) {
+    public static GetEvaluationResponse of(GetEvaluationDTO dto) {
         return new GetEvaluationResponse(
-                keyword.getId(), keyword.getType().getDescription(), keyword.getDescription());
+                dto.evaluationId(),
+                dto.type().getDescription(),
+                dto.keyword().getDescription(),
+                dto.isSelected());
     }
 }

--- a/api/src/main/java/com/dnd/sbooky/api/support/error/ApiControllerAdvice.java
+++ b/api/src/main/java/com/dnd/sbooky/api/support/error/ApiControllerAdvice.java
@@ -1,8 +1,11 @@
 package com.dnd.sbooky.api.support.error;
 
 import com.dnd.sbooky.api.support.response.ApiResponse;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -23,6 +26,20 @@ public class ApiControllerAdvice {
 
         return ResponseEntity.status(e.getErrorType().getStatus())
                 .body(ApiResponse.error(e.getErrorType(), e.getData()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<?>> handleMethodArgumentNotValidException(
+            MethodArgumentNotValidException e) {
+        log.info("MethodArgumentNotValidException = {}", e.getMessage());
+
+        List<String> errorMessages =
+                e.getBindingResult().getFieldErrors().stream()
+                        .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                        .toList();
+
+        return ResponseEntity.status(ErrorType.REQUEST_VALIDATION_FAILED.getStatus())
+                .body(ApiResponse.error(ErrorType.REQUEST_VALIDATION_FAILED, errorMessages));
     }
 
     @ExceptionHandler(MissingRequestCookieException.class)

--- a/api/src/main/java/com/dnd/sbooky/api/support/error/ErrorCode.java
+++ b/api/src/main/java/com/dnd/sbooky/api/support/error/ErrorCode.java
@@ -3,17 +3,32 @@ package com.dnd.sbooky.api.support.error;
 public enum ErrorCode {
 
     // TODO: 에러 코드 추가 필요 (Domain + HTTP Status + [Number])
+
+    // Server Error
     E500,
-    E400,
+    E400_1,
+    E400_2,
     E403,
     E404,
+
+    // Member Error
+    MEMBER_404,
+
+    // Book Error
     BOOK_400_1,
     BOOK_403,
     BOOK_404,
-    MEMBER_404,
+
+    // Security Error
     SECURITY_401_2,
     SECURITY_401_3,
     SECURITY_404_1,
+    SECURITY_401_1,
+
+    // Item Error
     ITEM_404,
-    SECURITY_401_1
+
+    // Evaluation Error
+    EVALUATION_404_1,
+    ;
 }

--- a/api/src/main/java/com/dnd/sbooky/api/support/error/ErrorType.java
+++ b/api/src/main/java/com/dnd/sbooky/api/support/error/ErrorType.java
@@ -17,7 +17,9 @@ public enum ErrorType {
 
     // Server Error
     DEFAULT_ERROR(INTERNAL_SERVER_ERROR, ErrorCode.E500, "Internal server error.", LogLevel.ERROR),
-    INVALID_PARAMETER(BAD_REQUEST, ErrorCode.E400, "Request parameter is invalid.", LogLevel.INFO),
+    INVALID_PARAMETER(BAD_REQUEST, ErrorCode.E400_1, "Request parameter is invalid.", LogLevel.INFO),
+    REQUEST_VALIDATION_FAILED(
+            BAD_REQUEST, ErrorCode.E400_2, "Request body is invalid", LogLevel.INFO),
 
     // Security Error
     INVALID_TOKEN(UNAUTHORIZED, ErrorCode.SECURITY_401_1, "Invalid token.", LogLevel.INFO),
@@ -35,7 +37,12 @@ public enum ErrorType {
             BAD_REQUEST, ErrorCode.BOOK_400_1, "Book read status is not completed.", LogLevel.INFO),
 
     // Item Error
-    ITEM_NOT_FOUND(NOT_FOUND, ErrorCode.ITEM_404, "Item was not found.", LogLevel.INFO);
+    ITEM_NOT_FOUND(NOT_FOUND, ErrorCode.ITEM_404, "Item was not found.", LogLevel.INFO),
+
+    // Evaluation Error
+    EVALUATION_KEYWORD_NOT_FOUND(
+            NOT_FOUND, ErrorCode.EVALUATION_404_1, "Evaluation keyword not found.", LogLevel.INFO),
+    ;
 
     private final HttpStatus status;
     private final ErrorCode code;

--- a/core/src/main/java/com/dnd/sbooky/core/evaluation/BookEvaluationEntity.java
+++ b/core/src/main/java/com/dnd/sbooky/core/evaluation/BookEvaluationEntity.java
@@ -1,0 +1,44 @@
+package com.dnd.sbooky.core.evaluation;
+
+import com.dnd.sbooky.core.book.MemberBookEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@Entity
+@Table(name = "book_evaluation")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BookEvaluationEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_book_id")
+    private MemberBookEntity memberBook;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "evaluation_id")
+    private Evaluation evaluation;
+
+    private BookEvaluationEntity(MemberBookEntity memberBookEntity, Evaluation evaluation) {
+        this.memberBook = memberBookEntity;
+        this.evaluation = evaluation;
+    }
+
+    public static BookEvaluationEntity newInstance(MemberBookEntity memberBookEntity, Evaluation evaluation) {
+        return new BookEvaluationEntity(memberBookEntity, evaluation);
+    }
+
+}

--- a/core/src/main/java/com/dnd/sbooky/core/evaluation/BookEvaluationEntity.java
+++ b/core/src/main/java/com/dnd/sbooky/core/evaluation/BookEvaluationEntity.java
@@ -13,7 +13,6 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-
 @Getter
 @Entity
 @Table(name = "book_evaluation")
@@ -30,15 +29,15 @@ public class BookEvaluationEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "evaluation_id")
-    private Evaluation evaluation;
+    private EvaluationEntity evaluation;
 
-    private BookEvaluationEntity(MemberBookEntity memberBookEntity, Evaluation evaluation) {
+    private BookEvaluationEntity(MemberBookEntity memberBookEntity, EvaluationEntity evaluation) {
         this.memberBook = memberBookEntity;
         this.evaluation = evaluation;
     }
 
-    public static BookEvaluationEntity newInstance(MemberBookEntity memberBookEntity, Evaluation evaluation) {
+    public static BookEvaluationEntity newInstance(
+            MemberBookEntity memberBookEntity, EvaluationEntity evaluation) {
         return new BookEvaluationEntity(memberBookEntity, evaluation);
     }
-
 }

--- a/core/src/main/java/com/dnd/sbooky/core/evaluation/BookEvaluationRepository.java
+++ b/core/src/main/java/com/dnd/sbooky/core/evaluation/BookEvaluationRepository.java
@@ -1,8 +1,13 @@
 package com.dnd.sbooky.core.evaluation;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface BookEvaluationRepository extends JpaRepository<BookEvaluationEntity, Long> {
 
+    @Modifying
+    @Query("DELETE FROM BookEvaluationEntity be WHERE be.memberBook.id = :memberBookId")
+    void deleteAllByMemberBookId(@Param("memberBookId") Long memberBookId);
 }

--- a/core/src/main/java/com/dnd/sbooky/core/evaluation/BookEvaluationRepository.java
+++ b/core/src/main/java/com/dnd/sbooky/core/evaluation/BookEvaluationRepository.java
@@ -1,0 +1,8 @@
+package com.dnd.sbooky.core.evaluation;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface BookEvaluationRepository extends JpaRepository<BookEvaluationEntity, Long> {
+
+}

--- a/core/src/main/java/com/dnd/sbooky/core/evaluation/EvaluationKeyword.java
+++ b/core/src/main/java/com/dnd/sbooky/core/evaluation/EvaluationKeyword.java
@@ -1,5 +1,6 @@
 package com.dnd.sbooky.core.evaluation;
 
+import java.util.Arrays;
 import lombok.Getter;
 
 @Getter
@@ -29,4 +30,13 @@ public enum EvaluationKeyword {
         this.type = type;
         this.description = description;
     }
+
+
+    public static EvaluationKeyword fromId(Long id) {
+        return Arrays.stream(values())
+                     .filter(keyword -> keyword.getId().equals(id))
+                     .findFirst()
+                     .orElseThrow(() -> new IllegalArgumentException("Invalid evaluation ID: " + id));
+    }
+
 }

--- a/core/src/main/java/com/dnd/sbooky/core/evaluation/EvaluationKeyword.java
+++ b/core/src/main/java/com/dnd/sbooky/core/evaluation/EvaluationKeyword.java
@@ -31,12 +31,10 @@ public enum EvaluationKeyword {
         this.description = description;
     }
 
-
     public static EvaluationKeyword fromId(Long id) {
         return Arrays.stream(values())
-                     .filter(keyword -> keyword.getId().equals(id))
-                     .findFirst()
-                     .orElseThrow(() -> new IllegalArgumentException("Invalid evaluation ID: " + id));
+                .filter(keyword -> keyword.getId().equals(id))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Invalid evaluation ID: " + id));
     }
-
 }

--- a/core/src/main/java/com/dnd/sbooky/core/evaluation/EvaluationRepository.java
+++ b/core/src/main/java/com/dnd/sbooky/core/evaluation/EvaluationRepository.java
@@ -2,4 +2,5 @@ package com.dnd.sbooky.core.evaluation;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface EvaluationRepository extends JpaRepository<EvaluationEntity, Long> {}
+public interface EvaluationRepository
+        extends JpaRepository<EvaluationEntity, Long>, EvaluationRepositoryCustom {}

--- a/core/src/main/java/com/dnd/sbooky/core/evaluation/EvaluationRepositoryCustom.java
+++ b/core/src/main/java/com/dnd/sbooky/core/evaluation/EvaluationRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.dnd.sbooky.core.evaluation;
+
+import com.dnd.sbooky.core.evaluation.dto.GetEvaluationDTO;
+import java.util.List;
+import org.springframework.data.repository.NoRepositoryBean;
+
+@NoRepositoryBean
+public interface EvaluationRepositoryCustom {
+
+    List<GetEvaluationDTO> findAllWithSelectedByMemberBookId(Long memberBookId);
+}

--- a/core/src/main/java/com/dnd/sbooky/core/evaluation/EvaluationRepositoryImpl.java
+++ b/core/src/main/java/com/dnd/sbooky/core/evaluation/EvaluationRepositoryImpl.java
@@ -1,0 +1,37 @@
+package com.dnd.sbooky.core.evaluation;
+
+import com.dnd.sbooky.core.evaluation.dto.GetEvaluationDTO;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class EvaluationRepositoryImpl implements EvaluationRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+    private final QEvaluationEntity evaluation = QEvaluationEntity.evaluationEntity;
+    private final QBookEvaluationEntity bookEvaluation = QBookEvaluationEntity.bookEvaluationEntity;
+
+    @Override
+    public List<GetEvaluationDTO> findAllWithSelectedByMemberBookId(Long memberBookId) {
+
+        return queryFactory
+                .select(
+                        Projections.constructor(
+                                GetEvaluationDTO.class,
+                                evaluation.id,
+                                evaluation.type,
+                                evaluation.keyword,
+                                bookEvaluation.isNotNull().as("isSelected")))
+                .from(evaluation)
+                .leftJoin(bookEvaluation)
+                .on(
+                        bookEvaluation
+                                .evaluation
+                                .id
+                                .eq(evaluation.id)
+                                .and(bookEvaluation.memberBook.id.eq(memberBookId)))
+                .fetch();
+    }
+}

--- a/core/src/main/java/com/dnd/sbooky/core/evaluation/dto/GetEvaluationDTO.java
+++ b/core/src/main/java/com/dnd/sbooky/core/evaluation/dto/GetEvaluationDTO.java
@@ -1,0 +1,7 @@
+package com.dnd.sbooky.core.evaluation.dto;
+
+import com.dnd.sbooky.core.evaluation.EvaluationKeyword;
+import com.dnd.sbooky.core.evaluation.EvaluationType;
+
+public record GetEvaluationDTO(
+        Long evaluationId, EvaluationType type, EvaluationKeyword keyword, boolean isSelected) {}


### PR DESCRIPTION
## 연관된 이슈

resolves #80 

## 작업 내용

책 평가 리스트를 조회할 때, 선택 여부(`isSelected`) 필드와 함께 조회되도록 변경하였습니다. 

## 리뷰 요구사항

> `BookEvaluation` Entity 정보가 필요해서 [완독한 책에 평가를 할 수 있다. #79 ](https://github.com/dnd-side-project/dnd-12th-9-backend/pull/79) PR에 이어서 작업한 것이라 #79 PR 먼저 확인해주시면 감사하겠습니다!

응답 형태에 대해서는 #80 이슈 댓글에 남겨두었습니다 