### PR TITLE
카카오 로그인 후 프론트 페이지로 리다이렉트 처리한다.

### DIFF
--- a/api/src/main/java/com/dnd/sbooky/api/docs/spec/AuthApiSpec.java
+++ b/api/src/main/java/com/dnd/sbooky/api/docs/spec/AuthApiSpec.java
@@ -1,5 +1,6 @@
 package com.dnd.sbooky.api.docs.spec;
 
+import com.dnd.sbooky.api.member.response.GetMemberResponse;
 import com.dnd.sbooky.api.support.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -9,6 +10,7 @@ import jakarta.servlet.http.HttpServletResponse;
 public interface AuthApiSpec {
     @Operation(
             summary = "토큰 재발급",
-            description = "refreshToken 검증 후 이상 없을 시 accessToken과 refreshToken을 재발급한다.")
-    ApiResponse<?> reissue(String refreshToken, HttpServletResponse response);
+            description =
+                    "refreshToken 검증 후 이상 없을 시 accessToken과 refreshToken을 재발급한다. 그리고 memberId를 반환한다.")
+    ApiResponse<GetMemberResponse> reissue(String refreshToken, HttpServletResponse response);
 }

--- a/api/src/main/java/com/dnd/sbooky/api/member/response/GetMemberResponse.java
+++ b/api/src/main/java/com/dnd/sbooky/api/member/response/GetMemberResponse.java
@@ -1,0 +1,7 @@
+package com.dnd.sbooky.api.member.response;
+
+public record GetMemberResponse(String memberId) {
+    public static GetMemberResponse of(String memberId) {
+        return new GetMemberResponse(memberId);
+    }
+}

--- a/api/src/main/java/com/dnd/sbooky/api/security/AuthController.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/AuthController.java
@@ -8,6 +8,7 @@ import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpHeaders.SET_COOKIE;
 
 import com.dnd.sbooky.api.docs.spec.AuthApiSpec;
+import com.dnd.sbooky.api.member.response.GetMemberResponse;
 import com.dnd.sbooky.api.support.RedisKey;
 import com.dnd.sbooky.api.support.response.ApiResponse;
 import jakarta.servlet.http.HttpServletResponse;
@@ -36,11 +37,16 @@ public class AuthController implements AuthApiSpec {
      * @return
      */
     @PostMapping("/auth/reissue")
-    public ApiResponse<?> reissue(
+    public ApiResponse<GetMemberResponse> reissue(
             @CookieValue(value = "refreshToken") String refreshToken, HttpServletResponse response) {
         tokenUsecase.validateRefreshToken(refreshToken);
         setToken(response, refreshToken);
-        return ApiResponse.success();
+        return ApiResponse.success(getMemberId(refreshToken));
+    }
+
+    private GetMemberResponse getMemberId(String refreshToken) {
+        Authentication authentication = tokenProvider.getAuthentication(refreshToken);
+        return GetMemberResponse.of(authentication.getName());
     }
 
     private void setToken(HttpServletResponse response, String refreshToken) {

--- a/api/src/main/java/com/dnd/sbooky/api/security/OAuth2SuccessHandler.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/OAuth2SuccessHandler.java
@@ -5,14 +5,11 @@ import static java.nio.charset.StandardCharsets.*;
 import static org.springframework.http.HttpHeaders.*;
 
 import com.dnd.sbooky.api.support.RedisKey;
-import com.dnd.sbooky.api.support.response.ApiResponse;
 import com.dnd.sbooky.core.RedisRepository;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
@@ -23,7 +20,6 @@ import org.springframework.stereotype.Component;
 public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
     private final TokenProvider tokenProvider;
-    private final ObjectMapper objectMapper;
     private final RedisRepository redisRepository;
 
     @Override
@@ -31,27 +27,15 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
             HttpServletRequest request, HttpServletResponse response, Authentication authentication)
             throws IOException {
 
-        String accessToken = tokenProvider.generateAccessToken(authentication);
-        setAccessTokenHeader(response, accessToken);
         String refreshToken = tokenProvider.generateRefreshToken(authentication);
         setRefreshTokenCookie(response, refreshToken);
         redisRepository.setData(getKey(authentication), refreshToken, REFRESH_TOKEN_EXPIRE_TIME);
-        objectMapper.writeValue(response.getWriter(), ApiResponse.success());
+        response.sendRedirect("http://localhost:3000/auth/callback");
     }
 
     private String getKey(Authentication authentication) {
         StringBuilder sb = new StringBuilder();
         return sb.append(RedisKey.refreshTokenPrefix).append(authentication.getName()).toString();
-    }
-
-    private void setAccessTokenHeader(HttpServletResponse response, String accessToken) {
-        StringBuilder sb = new StringBuilder();
-        sb.append(TOKEN_PREFIX).append(accessToken);
-        response.setHeader(AUTHORIZATION, sb.toString());
-        response.setStatus(HttpServletResponse.SC_OK);
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        response.setCharacterEncoding(UTF_8.name());
-        response.isCommitted();
     }
 
     private void setRefreshTokenCookie(HttpServletResponse response, String refreshToken) {

--- a/api/src/main/java/com/dnd/sbooky/api/security/OAuth2SuccessHandler.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/OAuth2SuccessHandler.java
@@ -10,6 +10,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
@@ -22,6 +23,9 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
     private final TokenProvider tokenProvider;
     private final RedisRepository redisRepository;
 
+    @Value("${login.redirect-uri}")
+    private String redirectUrl;
+
     @Override
     public void onAuthenticationSuccess(
             HttpServletRequest request, HttpServletResponse response, Authentication authentication)
@@ -30,7 +34,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         String refreshToken = tokenProvider.generateRefreshToken(authentication);
         setRefreshTokenCookie(response, refreshToken);
         redisRepository.setData(getKey(authentication), refreshToken, REFRESH_TOKEN_EXPIRE_TIME);
-        response.sendRedirect("http://localhost:3000/auth/callback");
+        response.sendRedirect(redirectUrl);
     }
 
     private String getKey(Authentication authentication) {

--- a/api/src/main/resources/security.yml
+++ b/api/src/main/resources/security.yml
@@ -19,3 +19,7 @@ spring:
 
 jwt:
   key: ${JWT_KEY}
+
+login:
+  redirect-uri: ${REDIRECT_URI}
+


### PR DESCRIPTION
## 연관된 이슈

closes #85 

## 작업 내용

기존 OAuth2SuccessHandler에서 반환하는 응답은 프론트에서 받을 수 없는 문제가 있었습니다. 이를 해결하기 위해, 프론트 페이지로 리다이렉트할 때 Refresh Token을 쿠키에 담아 전달하고, 프론트 측에서는 쿠키를 사용해 기존에 존재하던 토큰 재발행 API를 호출하여 Access Token과 Refresh Token을 새로 받는 방식으로 수정하였습니다.

## 리뷰 요구사항

프론트 개발자분과 논의한 결과, http://localhost:3000/auth/callback 로 리다이렉트 처리하기로 하였는데, 쿠키의 secure 속성이 true로 설정되어 있어 제대로 전달될지 확실하지 않습니다.