### PR TITLE
아이템 엔티티에 code 칼럼을 제거하고 Enum으로 관리한다.

### DIFF
--- a/api/src/main/java/com/dnd/sbooky/api/item/FindEquippedItemUsecase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/FindEquippedItemUsecase.java
@@ -24,7 +24,8 @@ public class FindEquippedItemUsecase {
                         .collect(
                                 Collectors.groupingBy(
                                         findItemDTO -> findItemDTO.type(),
-                                        Collectors.mapping(findItemDTO -> ItemCode.toCode(findItemDTO.id()), Collectors.toList())));
+                                        Collectors.mapping(
+                                                findItemDTO -> ItemCode.toCode(findItemDTO.id()), Collectors.toList())));
         return FindEquippedItemsResponse.from(equippedItems);
     }
 }

--- a/api/src/main/java/com/dnd/sbooky/api/item/FindEquippedItemUsecase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/FindEquippedItemUsecase.java
@@ -1,6 +1,7 @@
 package com.dnd.sbooky.api.item;
 
 import com.dnd.sbooky.api.item.response.FindEquippedItemsResponse;
+import com.dnd.sbooky.core.item.ItemCode;
 import com.dnd.sbooky.core.item.ItemType;
 import com.dnd.sbooky.core.item.MemberItemRepository;
 import java.util.List;
@@ -23,7 +24,7 @@ public class FindEquippedItemUsecase {
                         .collect(
                                 Collectors.groupingBy(
                                         findItemDTO -> findItemDTO.type(),
-                                        Collectors.mapping(findItemDTO -> findItemDTO.code(), Collectors.toList())));
+                                        Collectors.mapping(findItemDTO -> ItemCode.toCode(findItemDTO.id()), Collectors.toList())));
         return FindEquippedItemsResponse.from(equippedItems);
     }
 }

--- a/api/src/main/java/com/dnd/sbooky/api/item/FindItemsUseCase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/FindItemsUseCase.java
@@ -27,7 +27,8 @@ public class FindItemsUseCase {
                                         findItemDTO -> findItemDTO.type(),
                                         Collectors.mapping(
                                                 findItemDTO ->
-                                                        FindItemResponse.from(findItemDTO.name(), ItemCode.toCode(findItemDTO.id())),
+                                                        FindItemResponse.from(
+                                                                findItemDTO.name(), ItemCode.toCode(findItemDTO.id())),
                                                 Collectors.toList())));
         return FindItemsResponse.from(items);
     }

--- a/api/src/main/java/com/dnd/sbooky/api/item/FindItemsUseCase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/FindItemsUseCase.java
@@ -2,6 +2,7 @@ package com.dnd.sbooky.api.item;
 
 import com.dnd.sbooky.api.item.response.FindItemResponse;
 import com.dnd.sbooky.api.item.response.FindItemsResponse;
+import com.dnd.sbooky.core.item.ItemCode;
 import com.dnd.sbooky.core.item.ItemType;
 import com.dnd.sbooky.core.item.MemberItemRepository;
 import java.util.List;
@@ -26,7 +27,7 @@ public class FindItemsUseCase {
                                         findItemDTO -> findItemDTO.type(),
                                         Collectors.mapping(
                                                 findItemDTO ->
-                                                        FindItemResponse.from(findItemDTO.name(), findItemDTO.code()),
+                                                        FindItemResponse.from(findItemDTO.name(), ItemCode.toCode(findItemDTO.id())),
                                                 Collectors.toList())));
         return FindItemsResponse.from(items);
     }

--- a/api/src/main/java/com/dnd/sbooky/api/item/SwitchEquippedItemUsecase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/SwitchEquippedItemUsecase.java
@@ -19,8 +19,8 @@ public class SwitchEquippedItemUsecase {
     private final MemberItemRepository memberItemRepository;
 
     public void switchEquippedItem(Long memberId, SwitchEquippedItemRequest request) {
-        unEquipItem(memberId, ItemCode.toCode(request.equippedItemCode()));
-        equipItem(memberId, ItemCode.toCode(request.toEquipItemCode()));
+        unEquipItem(memberId, ItemCode.toId(request.equippedItemCode()));
+        equipItem(memberId, ItemCode.toId(request.toEquipItemCode()));
     }
 
     private void unEquipItem(Long memberId, Long equippedItemId) {

--- a/api/src/main/java/com/dnd/sbooky/api/item/SwitchEquippedItemUsecase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/SwitchEquippedItemUsecase.java
@@ -4,6 +4,7 @@ import static com.dnd.sbooky.api.support.error.ErrorType.*;
 
 import com.dnd.sbooky.api.item.exception.MemberHasNotItemException;
 import com.dnd.sbooky.api.item.request.SwitchEquippedItemRequest;
+import com.dnd.sbooky.core.item.ItemCode;
 import com.dnd.sbooky.core.item.MemberItemEntity;
 import com.dnd.sbooky.core.item.MemberItemRepository;
 import lombok.RequiredArgsConstructor;
@@ -18,8 +19,8 @@ public class SwitchEquippedItemUsecase {
     private final MemberItemRepository memberItemRepository;
 
     public void switchEquippedItem(Long memberId, SwitchEquippedItemRequest request) {
-        unEquipItem(memberId, request.equippedItemId());
-        equipItem(memberId, request.toEquipItemId());
+        unEquipItem(memberId, ItemCode.toCode(request.equippedItemCode()));
+        equipItem(memberId, ItemCode.toCode(request.toEquipItemCode()));
     }
 
     private void unEquipItem(Long memberId, Long equippedItemId) {

--- a/api/src/main/java/com/dnd/sbooky/api/item/request/SwitchEquippedItemRequest.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/request/SwitchEquippedItemRequest.java
@@ -5,5 +5,5 @@ import jakarta.validation.constraints.NotNull;
 
 @Schema(description = "아이템 착용 요청 DTO")
 public record SwitchEquippedItemRequest(
-        @Schema(description = "기존 착용하고 있는 아이템") @NotNull Long equippedItemId,
-        @Schema(description = "앞으로 착용할 아이템") @NotNull Long toEquipItemId) {}
+        @Schema(description = "기존 착용하고 있는 아이템") @NotNull String equippedItemCode,
+        @Schema(description = "앞으로 착용할 아이템") @NotNull String toEquipItemCode) {}

--- a/api/src/main/java/com/dnd/sbooky/api/member/PerformOnboardingUseCase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/member/PerformOnboardingUseCase.java
@@ -5,6 +5,7 @@ import static com.dnd.sbooky.api.support.error.ErrorType.MEMBER_NOT_FOUND;
 import com.dnd.sbooky.api.item.ObtainItemUseCase;
 import com.dnd.sbooky.api.member.exception.MemberNotFoundException;
 import com.dnd.sbooky.api.member.request.PerformOnboardingRequest;
+import com.dnd.sbooky.core.item.ItemCode;
 import com.dnd.sbooky.core.member.MemberEntity;
 import com.dnd.sbooky.core.member.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -15,7 +16,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional
 public class PerformOnboardingUseCase {
-    public static final long BASIC_GHOST_ID = 2L;
     private final MemberRepository memberRepository;
     private final ObtainItemUseCase obtainItemUseCase;
 
@@ -25,6 +25,6 @@ public class PerformOnboardingUseCase {
                         .findById(memberId)
                         .orElseThrow(() -> new MemberNotFoundException(MEMBER_NOT_FOUND));
         member.updateNickname(request.nickname());
-        obtainItemUseCase.obtainItem(memberId, BASIC_GHOST_ID);
+        obtainItemUseCase.obtainItem(memberId, ItemCode.BASIC.getId());
     }
 }

--- a/core/src/main/java/com/dnd/sbooky/core/Initializer.java
+++ b/core/src/main/java/com/dnd/sbooky/core/Initializer.java
@@ -28,8 +28,8 @@ public class Initializer {
     public void init() {
         MemberEntity memberEntity = memberRepository.save(MemberEntity.newInstance("test1", "test1"));
         likeRepository.save(LikeEntity.newInstance(memberEntity.getId()));
-        itemRepository.save(ItemEntity.newInstance(ItemType.CHARACTER, "떠돌이 유령", "mummy_ghost"));
-        itemRepository.save(ItemEntity.newInstance(ItemType.CHARACTER, "유령", "basic_ghost"));
+        itemRepository.save(ItemEntity.newInstance(1L, ItemType.CHARACTER, "떠돌이 유령"));
+        itemRepository.save(ItemEntity.newInstance(2L, ItemType.CHARACTER, "유령"));
 
         Arrays.stream(EvaluationKeyword.values())
                 .forEach(keyword -> evaluationRepository.save(EvaluationEntity.newInstance(keyword)));

--- a/core/src/main/java/com/dnd/sbooky/core/item/ItemCode.java
+++ b/core/src/main/java/com/dnd/sbooky/core/item/ItemCode.java
@@ -14,10 +14,11 @@ public enum ItemCode {
         this.code = code;
     }
 
-    public static Long toCode(String code){
+    public static Long toId(String code) {
         return Arrays.stream(values())
                 .filter(codes -> codes.code.equals(code))
                 .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("Invalid code: " + code)).id;
+                .orElseThrow(() -> new IllegalArgumentException("Invalid code: " + code))
+                .id;
     }
 }

--- a/core/src/main/java/com/dnd/sbooky/core/item/ItemCode.java
+++ b/core/src/main/java/com/dnd/sbooky/core/item/ItemCode.java
@@ -29,6 +29,7 @@ public enum ItemCode {
                 .orElseThrow(() -> new IllegalArgumentException("Invalid id: " + id))
                 .code;
     }
+
     public Long getId() {
         return id;
     }

--- a/core/src/main/java/com/dnd/sbooky/core/item/ItemCode.java
+++ b/core/src/main/java/com/dnd/sbooky/core/item/ItemCode.java
@@ -21,4 +21,15 @@ public enum ItemCode {
                 .orElseThrow(() -> new IllegalArgumentException("Invalid code: " + code))
                 .id;
     }
+
+    public static String toCode(Long id) {
+        return Arrays.stream(values())
+                .filter(codes -> codes.id.equals(id))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Invalid id: " + id))
+                .code;
+    }
+    public Long getId() {
+        return id;
+    }
 }

--- a/core/src/main/java/com/dnd/sbooky/core/item/ItemCode.java
+++ b/core/src/main/java/com/dnd/sbooky/core/item/ItemCode.java
@@ -1,0 +1,23 @@
+package com.dnd.sbooky.core.item;
+
+import java.util.Arrays;
+
+public enum ItemCode {
+    MUMMY(1L, "mummy_ghost"),
+    BASIC(2L, "basic_ghost");
+
+    private final Long id;
+    private final String code;
+
+    ItemCode(Long id, String code) {
+        this.id = id;
+        this.code = code;
+    }
+
+    public static Long toCode(String code){
+        return Arrays.stream(values())
+                .filter(codes -> codes.code.equals(code))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Invalid code: " + code)).id;
+    }
+}

--- a/core/src/main/java/com/dnd/sbooky/core/item/ItemEntity.java
+++ b/core/src/main/java/com/dnd/sbooky/core/item/ItemEntity.java
@@ -21,7 +21,6 @@ public class ItemEntity extends BaseEntity {
     private static final String ENTITY_PREFIX = "item";
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = ENTITY_PREFIX + "_id", nullable = false)
     private Long id;
 
@@ -31,18 +30,13 @@ public class ItemEntity extends BaseEntity {
 
     @Column(name = ENTITY_PREFIX + "_name", nullable = false)
     private String name;
-
-    @Column(name = ENTITY_PREFIX + "_code", nullable = false)
-    private String code;
-
     @Builder
-    private ItemEntity(ItemType type, String name, String code) {
+    private ItemEntity(Long id, ItemType type, String name) {
+        this.id = id;
         this.type = type;
         this.name = name;
-        this.code = code;
     }
-
-    public static ItemEntity newInstance(ItemType type, String name, String code) {
-        return ItemEntity.builder().type(type).name(name).code(code).build();
+    public static ItemEntity newInstance(Long id, ItemType type, String name) {
+        return ItemEntity.builder().id(id).type(type).name(name).build();
     }
 }

--- a/core/src/main/java/com/dnd/sbooky/core/item/ItemEntity.java
+++ b/core/src/main/java/com/dnd/sbooky/core/item/ItemEntity.java
@@ -5,8 +5,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
@@ -30,12 +28,14 @@ public class ItemEntity extends BaseEntity {
 
     @Column(name = ENTITY_PREFIX + "_name", nullable = false)
     private String name;
+
     @Builder
     private ItemEntity(Long id, ItemType type, String name) {
         this.id = id;
         this.type = type;
         this.name = name;
     }
+
     public static ItemEntity newInstance(Long id, ItemType type, String name) {
         return ItemEntity.builder().id(id).type(type).name(name).build();
     }

--- a/core/src/main/java/com/dnd/sbooky/core/item/MemberItemRepositoryImpl.java
+++ b/core/src/main/java/com/dnd/sbooky/core/item/MemberItemRepositoryImpl.java
@@ -17,7 +17,7 @@ public class MemberItemRepositoryImpl implements MemberItemRepositoryCustom {
 
     public List<FindItemDTO> findItemsByMemberId(Long memberId) {
         return queryFactory
-                .select(Projections.constructor(FindItemDTO.class, item.code, item.name, item.type))
+                .select(Projections.constructor(FindItemDTO.class, item.id, item.name, item.type))
                 .from(memberItem)
                 .join(memberItem.itemEntity, item)
                 .where(memberItem.memberEntity.id.eq(memberId))
@@ -27,7 +27,7 @@ public class MemberItemRepositoryImpl implements MemberItemRepositoryCustom {
     @Override
     public List<FindItemDTO> findEquippedItemsByMemberId(Long memberId) {
         return queryFactory
-                .select(Projections.constructor(FindItemDTO.class, item.code, item.name, item.type))
+                .select(Projections.constructor(FindItemDTO.class, item.id, item.name, item.type))
                 .from(memberItem)
                 .join(memberItem.itemEntity, item)
                 .where(memberItem.memberEntity.id.eq(memberId), isEquipped())

--- a/core/src/main/java/com/dnd/sbooky/core/item/dto/FindItemDTO.java
+++ b/core/src/main/java/com/dnd/sbooky/core/item/dto/FindItemDTO.java
@@ -2,4 +2,4 @@ package com.dnd.sbooky.core.item.dto;
 
 import com.dnd.sbooky.core.item.ItemType;
 
-public record FindItemDTO(String code, String name, ItemType type) {}
+public record FindItemDTO(Long id, String name, ItemType type) {}


### PR DESCRIPTION
## 연관된 이슈

closes #97 

## 작업 내용

- 아이템 관련 조회시 code를 사용 사용하는 방식에서 PK를 사용하여 조회하는 방식으로 변경하였습니다.
- ItemCode Enum을 만들어서 ItemEnttiy의 PK와 프론트 통신에서 사용하는 Code를 매핑하였습니다.
- ItemEntity PK는 직접 할당 방식으로 사용하도록 변경

## 리뷰 요구사항

