### PR TITLE
쿼리 스트링을 활용해 RefreshToken 반환

### DIFF
--- a/api/src/main/java/com/dnd/sbooky/api/security/OAuth2SuccessHandler.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/OAuth2SuccessHandler.java
@@ -1,8 +1,6 @@
 package com.dnd.sbooky.api.security;
 
 import static com.dnd.sbooky.api.security.TokenConstants.*;
-import static java.nio.charset.StandardCharsets.*;
-import static org.springframework.http.HttpHeaders.*;
 
 import com.dnd.sbooky.api.support.RedisKey;
 import com.dnd.sbooky.core.RedisRepository;
@@ -11,10 +9,10 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @RequiredArgsConstructor
 @Component
@@ -24,7 +22,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
     private final RedisRepository redisRepository;
 
     @Value("${login.redirect-uri}")
-    private String redirectUrl;
+    private String redirectUri;
 
     @Override
     public void onAuthenticationSuccess(
@@ -32,9 +30,13 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
             throws IOException {
 
         String refreshToken = tokenProvider.generateRefreshToken(authentication);
-        setRefreshTokenCookie(response, refreshToken);
         redisRepository.setData(getKey(authentication), refreshToken, REFRESH_TOKEN_EXPIRE_TIME);
-        response.sendRedirect(redirectUrl);
+        String redirectUri =
+                UriComponentsBuilder.fromUriString(this.redirectUri)
+                        .queryParam("refreshToken", refreshToken)
+                        .build()
+                        .toUriString();
+        response.sendRedirect(redirectUri);
     }
 
     private String getKey(Authentication authentication) {
@@ -42,15 +44,16 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         return sb.append(RedisKey.refreshTokenPrefix).append(authentication.getName()).toString();
     }
 
-    private void setRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
-        ResponseCookie cookie =
-                ResponseCookie.from(REFRESH_TOKEN, refreshToken)
-                        .secure(true)
-                        .sameSite(SameSite.NONE.getValue())
-                        .httpOnly(true)
-                        .maxAge(REFRESH_TOKEN_EXPIRE_TIME)
-                        .path("/")
-                        .build();
-        response.addHeader(SET_COOKIE, cookie.toString());
-    }
+    //    private void setRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
+    //        ResponseCookie cookie =
+    //                ResponseCookie.from(REFRESH_TOKEN, refreshToken)
+    //                        .secure(true)
+    //                        .sameSite(SameSite.NONE.getValue())
+    //                        .httpOnly(true)
+    //                        .maxAge(REFRESH_TOKEN_EXPIRE_TIME)
+    //                        .path("/")
+    //                        .build();
+    //        response.addHeader(SET_COOKIE, cookie.toString());
+    //    }
+
 }


### PR DESCRIPTION
## 연관된 이슈

closes #109 

## 작업 내용

리다이렉트 시 쿠키를 전달하기 위해 서브 도메인을 적용했으나, Next.js에서 쿠키를 정상적으로 수신하지 못하는 문제가 발생했습니다. 마감 기한이 촉박하여, 임시 방안으로 쿼리 스트링을 활용해 RefreshToken을 전달하도록 변경하였습니다.

추후에는 카카오 로그인을 Next Auth를 사용하는 방식으로 개선할 예정입니다.

## 리뷰 요구사항

Swagger Test시 쿠키가 전달되지 않는 상황 발생 후 조사 결과 Swagger에서는 쿠키 인증 지원 하지 않음.


<img width="741" alt="스크린샷 2025-02-16 오후 7 12 06" src="https://github.com/user-attachments/assets/c543a728-004b-492a-9616-d6277f260699" />

https://swagger.io/docs/specification/v3_0/authentication/cookie-authentication/

PostMan으로 쿠키 세팅하고 테스트 결과 성공

<img width="304" alt="스크린샷 2025-02-16 오후 7 10 51" src="https://github.com/user-attachments/assets/85eb7487-9d88-4c35-b182-77fde86b8a92" />
<img width="817" alt="스크린샷 2025-02-16 오후 7 10 59" src="https://github.com/user-attachments/assets/862ba777-5b60-4b01-b1ba-cad99c94f901" />

