### PR TITLE
OpenFeign에 타임아웃, 재시도를 설정한다.

### DIFF
--- a/clients/src/main/java/com/dnd/sbooky/clients/config/FeignClientConfig.java
+++ b/clients/src/main/java/com/dnd/sbooky/clients/config/FeignClientConfig.java
@@ -1,11 +1,13 @@
 package com.dnd.sbooky.clients.config;
 
+import feign.Logger;
 import feign.Request;
 import feign.Retryer;
 import java.time.Duration;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 @Configuration
 @EnableFeignClients(basePackages = "com.dnd.sbooky.clients")
@@ -38,4 +40,14 @@ class FeignClientConfig {
     Retryer.Default feignRetryer() {
         return new Retryer.Default(RETRY_PERIOD, RETRY_MAX_PERIOD, RETRY_MAX_ATTEMPTS);
     }
+
+    /**
+     * Logging Setting
+     */
+    @Profile("local")
+    @Bean
+    Logger.Level feignLoggerLevel() {
+        return Logger.Level.BASIC;
+    }
+
 }

--- a/clients/src/main/java/com/dnd/sbooky/clients/config/FeignClientConfig.java
+++ b/clients/src/main/java/com/dnd/sbooky/clients/config/FeignClientConfig.java
@@ -21,7 +21,15 @@ class FeignClientConfig {
     private static final int RETRY_MAX_ATTEMPTS = 3;
 
     /**
-     * Timeout Setting
+     * HTTP 요청에 대한 Timeout 설정
+     * <p>
+     *
+     * <ul>
+     *  <li>Connection Timeout: {@value CONNECT_TIMEOUT_MILLIS}ms - 서버와의 연결 시도 제한 시간
+     *  <li>Read Timeout: {@value READ_TIMEOUT_MILLIS}ms - 서버로부터 응답 대기 제한 시간
+     * </ul>
+     *
+     * @return Request.Options 타임아웃 설정 객체
      */
     @Bean
     Request.Options feignOptions() {
@@ -30,7 +38,20 @@ class FeignClientConfig {
     }
 
     /**
-     * Retry Setting
+     * HTTP 요청 실패 시 재시도 설정
+     * <p>
+     *
+     * <ul>
+     *  <li>초기 재시도 간격: {@value RETRY_PERIOD}ms
+     *  <li>최대 재시도 간격: {@value RETRY_MAX_PERIOD}ms
+     *  <li>최대 재시도 횟수: {@value RETRY_MAX_ATTEMPTS}회
+     * </ul>
+     *
+     * <p>
+     * 재시도 간격은 {@value RETRY_PERIOD}ms 에서 시작하여 점차 증가하며,
+     * 최대 {@value RETRY_MAX_PERIOD}ms를 초과하지 않습니다.
+     *
+     * @return Retryer.Default 재시도 설정 객체
      */
     @Bean
     Retryer.Default feignRetryer() {
@@ -38,7 +59,11 @@ class FeignClientConfig {
     }
 
     /**
-     * Logging Setting
+     * FeignClient 로깅 설정
+     * <p>
+     * 운영 환경(prod)을 제외한 모든 환경에서 기본(BASIC) 레벨의 로깅을 활성화합니다.
+     *
+     * @return Logger.Level 로깅 레벨
      */
     @Profile("!prod")
     @Bean

--- a/clients/src/main/java/com/dnd/sbooky/clients/config/FeignClientConfig.java
+++ b/clients/src/main/java/com/dnd/sbooky/clients/config/FeignClientConfig.java
@@ -1,8 +1,27 @@
 package com.dnd.sbooky.clients.config;
 
+import feign.Request;
+import java.time.Duration;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @EnableFeignClients(basePackages = "com.dnd.sbooky.clients")
-class FeignClientConfig {}
+class FeignClientConfig {
+
+    private static final long CONNECT_TIMEOUT_MILLIS = 5000L;
+    private static final long READ_TIMEOUT_MILLIS = 5000L;
+
+    /**
+     * Timeout Setting
+     */
+    @Bean
+    Request.Options feignOptions() {
+        return new Request.Options(
+                Duration.ofMillis(CONNECT_TIMEOUT_MILLIS),
+                Duration.ofMillis(READ_TIMEOUT_MILLIS),
+                true
+        );
+    }
+}

--- a/clients/src/main/java/com/dnd/sbooky/clients/config/FeignClientConfig.java
+++ b/clients/src/main/java/com/dnd/sbooky/clients/config/FeignClientConfig.java
@@ -26,12 +26,8 @@ class FeignClientConfig {
     @Bean
     Request.Options feignOptions() {
         return new Request.Options(
-                Duration.ofMillis(CONNECT_TIMEOUT_MILLIS),
-                Duration.ofMillis(READ_TIMEOUT_MILLIS),
-                true
-        );
+                Duration.ofMillis(CONNECT_TIMEOUT_MILLIS), Duration.ofMillis(READ_TIMEOUT_MILLIS), true);
     }
-
 
     /**
      * Retry Setting
@@ -49,5 +45,4 @@ class FeignClientConfig {
     Logger.Level feignLoggerLevel() {
         return Logger.Level.BASIC;
     }
-
 }

--- a/clients/src/main/java/com/dnd/sbooky/clients/config/FeignClientConfig.java
+++ b/clients/src/main/java/com/dnd/sbooky/clients/config/FeignClientConfig.java
@@ -40,7 +40,7 @@ class FeignClientConfig {
     /**
      * Logging Setting
      */
-    @Profile("local")
+    @Profile("!prod")
     @Bean
     Logger.Level feignLoggerLevel() {
         return Logger.Level.BASIC;

--- a/clients/src/main/java/com/dnd/sbooky/clients/config/FeignClientConfig.java
+++ b/clients/src/main/java/com/dnd/sbooky/clients/config/FeignClientConfig.java
@@ -1,6 +1,7 @@
 package com.dnd.sbooky.clients.config;
 
 import feign.Request;
+import feign.Retryer;
 import java.time.Duration;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Bean;
@@ -13,6 +14,10 @@ class FeignClientConfig {
     private static final long CONNECT_TIMEOUT_MILLIS = 5000L;
     private static final long READ_TIMEOUT_MILLIS = 5000L;
 
+    private static final long RETRY_PERIOD = 100L;
+    private static final long RETRY_MAX_PERIOD = 2000L;
+    private static final int RETRY_MAX_ATTEMPTS = 3;
+
     /**
      * Timeout Setting
      */
@@ -23,5 +28,14 @@ class FeignClientConfig {
                 Duration.ofMillis(READ_TIMEOUT_MILLIS),
                 true
         );
+    }
+
+
+    /**
+     * Retry Setting
+     */
+    @Bean
+    Retryer.Default feignRetryer() {
+        return new Retryer.Default(RETRY_PERIOD, RETRY_MAX_PERIOD, RETRY_MAX_ATTEMPTS);
     }
 }

--- a/clients/src/main/resources/feign.yml
+++ b/clients/src/main/resources/feign.yml
@@ -1,3 +1,10 @@
 kakao:
   api:
     authorization: ${KAKAO_CLIENT_ID}
+
+---
+spring.config.activate.on-profile: local
+
+logging:
+  level:
+    com.dnd.sbooky.clients: DEBUG


### PR DESCRIPTION
## 연관된 이슈

resolves #98 

## 작업 내용

**타임아웃 설정**

- connect timeout: 5000ms
- read timeout: 5000ms

**재시도 설정**

- 재시도 간격: 100ms
- 최대 재시도 간격: 2000ms
- 최대 재시도 시도 횟수: 3번

**로깅 설정**

BASIC 단계로 설정
- 요청 메서드
- URI와 응답 상태코드
- 실행 시간 로깅

## 리뷰 요구사항

local, dev 환경에 로깅을 처리했습니다. 

실제 환경에서 어느정도의 시간이 걸리는지 테스트해보고, 타임아웃을 설정하는게 가장 좋은 선택지인 것 같아서 일단 기본적인 세팅만 해둔 상태입니다. 

기본 세팅의 경우, 

- connect timeout: 10s
- read timeout: 60s 
- Retry는 설정되지 않음 

으로 되어있기 때문에 dev 환경에서 로그를 확인한 후 적절한 값으로 변경하면 좋을 것 같아요! 

> 로컬 환경의 경우, 67ms~184ms 정도로 측정되긴 했습니다.