### PR TITLE
헤더에 토큰이 없는 경우 별도의 에러 타입을 설정한다.

### DIFF
--- a/api/src/main/java/com/dnd/sbooky/api/security/FailedAuthenticationEntryPoint.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/FailedAuthenticationEntryPoint.java
@@ -1,0 +1,36 @@
+package com.dnd.sbooky.api.security;
+
+import com.dnd.sbooky.api.support.error.ErrorType;
+import com.dnd.sbooky.api.support.response.ApiResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class FailedAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException)
+            throws IOException, ServletException {
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        objectMapper.writeValue(
+                response.getWriter(), ApiResponse.error(ErrorType.AUTHENTICATION_FAILED));
+    }
+}

--- a/api/src/main/java/com/dnd/sbooky/api/security/SecurityConfig.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/SecurityConfig.java
@@ -1,6 +1,5 @@
 package com.dnd.sbooky.api.security;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -27,7 +26,9 @@ public class SecurityConfig {
     private final CustomOAuth2UserService oAuth2UserService;
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
     private final TokenAuthenticationFilter tokenAuthenticationFilter;
-    private final ObjectMapper objectMapper;
+    private final TokenExceptionFilter tokenExceptionFilter;
+    private final FailedAuthenticationEntryPoint failedAuthenticationEntryPoint;
+
     private static final String[] allowUrls = {
         "/swagger-resources/**",
         "/swagger-ui/**",
@@ -73,9 +74,11 @@ public class SecurityConfig {
                                         .authorizationEndpoint(endPoint -> endPoint.baseUri("/api/login"))
                                         .userInfoEndpoint(c -> c.userService(oAuth2UserService))
                                         .successHandler(oAuth2SuccessHandler))
+                .exceptionHandling(
+                        exceptionHandling ->
+                                exceptionHandling.authenticationEntryPoint(failedAuthenticationEntryPoint))
                 .addFilterBefore(tokenAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-                .addFilterBefore(
-                        new TokenExceptionFilter(objectMapper), tokenAuthenticationFilter.getClass());
+                .addFilterBefore(tokenExceptionFilter, tokenAuthenticationFilter.getClass());
 
         return http.build();
     }

--- a/api/src/main/java/com/dnd/sbooky/api/support/error/ErrorCode.java
+++ b/api/src/main/java/com/dnd/sbooky/api/support/error/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
     SECURITY_401_3,
     SECURITY_404_1,
     SECURITY_401_1,
+    SECURITY_401_4,
 
     // Item Error
     ITEM_404,

--- a/api/src/main/java/com/dnd/sbooky/api/support/error/ErrorType.java
+++ b/api/src/main/java/com/dnd/sbooky/api/support/error/ErrorType.java
@@ -25,6 +25,8 @@ public enum ErrorType {
     INVALID_TOKEN(UNAUTHORIZED, ErrorCode.SECURITY_401_1, "Invalid token.", LogLevel.INFO),
     INVALID_SIGNATURE(UNAUTHORIZED, ErrorCode.SECURITY_401_2, "Invalid signature", LogLevel.INFO),
     EXPIRED_TOKEN(UNAUTHORIZED, ErrorCode.SECURITY_401_3, "Expired accessToken", LogLevel.INFO),
+    AUTHENTICATION_FAILED(
+            UNAUTHORIZED, ErrorCode.SECURITY_401_4, "Authentication failed.", LogLevel.INFO),
     NOT_FOUND_TOKEN(NOT_FOUND, ErrorCode.SECURITY_404_1, "Not found token", LogLevel.INFO),
 
     // Member Error


### PR DESCRIPTION
## 연관된 이슈

resolves #116 

## 작업 내용

Authorization 헤더가 없는 상태에서 요청한 경우 공통 응답 예외로 응답하도록 수정하였습니다. 

_로그인을 하지 않고 `/api/items` 요청한 경우_
<img width="868" alt="image" src="https://github.com/user-attachments/assets/fecc8413-864e-46f2-b43e-1b326ad8bcb9" />


## 리뷰 요구사항

추가적으로 Security Configuration에서 아래와 같은 항목들이 필요해보여서 추후에 추가하면 좋을 것 같아요~

_볼드체는 관련 키워드입니다._

- OAuth2 로그인 처리 중 실패한 경우 (**SimpleUrlAuthenticationFailureHandler**)
- logout 처리 (**LogoutHandler**, 레디스에서 토큰 제거 및 요청한 사람의 쿠키 없애기)