### PR TITLE
회원은 포인트를 지불해 아이템 뽑기를 수행할 수 있다.

### DIFF
--- a/api/src/main/java/com/dnd/sbooky/api/docs/spec/DrawItemApiSpec.java
+++ b/api/src/main/java/com/dnd/sbooky/api/docs/spec/DrawItemApiSpec.java
@@ -1,0 +1,15 @@
+package com.dnd.sbooky.api.docs.spec;
+
+import com.dnd.sbooky.api.item.response.DrawItemResponse;
+import com.dnd.sbooky.api.support.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@Tag(name = "[Item API]", description = "아이템 관련된 API")
+@SecurityRequirement(name = "access-token")
+public interface DrawItemApiSpec {
+    @Operation(summary = "아이템 뽑기", description = "아이템을 랜덤을 뽑는다.")
+    ApiResponse<DrawItemResponse> drawItem(UserDetails user);
+}

--- a/api/src/main/java/com/dnd/sbooky/api/item/DrawItemController.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/DrawItemController.java
@@ -1,0 +1,31 @@
+package com.dnd.sbooky.api.item;
+
+import com.dnd.sbooky.api.docs.spec.DrawItemApiSpec;
+import com.dnd.sbooky.api.item.response.DrawItemResponse;
+import com.dnd.sbooky.api.support.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class DrawItemController implements DrawItemApiSpec {
+
+    private final DrawItemUsecase drawItemUsecase;
+
+    @PostMapping("/items/member")
+    public ApiResponse<DrawItemResponse> drawItem(
+            @Parameter(hidden = true) @AuthenticationPrincipal UserDetails user) {
+        Long memberId = extractMemberId(user);
+        return ApiResponse.success(drawItemUsecase.drawItem(memberId));
+    }
+
+    private Long extractMemberId(UserDetails user) {
+        return Long.valueOf(user.getUsername());
+    }
+}

--- a/api/src/main/java/com/dnd/sbooky/api/item/DrawItemController.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/DrawItemController.java
@@ -18,7 +18,7 @@ public class DrawItemController implements DrawItemApiSpec {
 
     private final DrawItemUsecase drawItemUsecase;
 
-    @PostMapping("/items/member")
+    @PostMapping("/items/draw")
     public ApiResponse<DrawItemResponse> drawItem(
             @Parameter(hidden = true) @AuthenticationPrincipal UserDetails user) {
         Long memberId = extractMemberId(user);

--- a/api/src/main/java/com/dnd/sbooky/api/item/DrawItemUsecase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/DrawItemUsecase.java
@@ -1,0 +1,62 @@
+package com.dnd.sbooky.api.item;
+
+import static com.dnd.sbooky.api.support.error.ErrorType.*;
+
+import com.dnd.sbooky.api.item.exception.ItemNotFoundException;
+import com.dnd.sbooky.api.item.response.DrawItemResponse;
+import com.dnd.sbooky.api.member.exception.MemberNotFoundException;
+import com.dnd.sbooky.api.point.AccumulatePointUseCase;
+import com.dnd.sbooky.core.item.ItemCode;
+import com.dnd.sbooky.core.item.ItemEntity;
+import com.dnd.sbooky.core.item.ItemRandomFetcher;
+import com.dnd.sbooky.core.item.ItemRepository;
+import com.dnd.sbooky.core.item.MemberItemEntity;
+import com.dnd.sbooky.core.item.MemberItemRepository;
+import com.dnd.sbooky.core.member.MemberEntity;
+import com.dnd.sbooky.core.member.MemberRepository;
+import com.dnd.sbooky.core.point.PointPolicy;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class DrawItemUsecase {
+
+    private final AccumulatePointUseCase accumulatePointUseCase;
+    private final ItemRepository itemRepository;
+    private final MemberRepository memberRepository;
+    private final MemberItemRepository memberItemRepository;
+
+    @Transactional
+    public DrawItemResponse drawItem(Long memberId) {
+        MemberEntity memberEntity =
+                memberRepository
+                        .findById(memberId)
+                        .orElseThrow(() -> new MemberNotFoundException(MEMBER_NOT_FOUND));
+        accumulatePointUseCase.accumulate(memberEntity, PointPolicy.DRAW_ITEM);
+        Long randomItemId = getRandomItemId();
+        ItemEntity itemEntity =
+                itemRepository
+                        .findById(randomItemId)
+                        .orElseThrow(() -> new ItemNotFoundException(ITEM_NOT_FOUND));
+
+        if (memberItemRepository.existsByMemberIdAndItemId(memberId, randomItemId)) {
+            return new DrawItemResponse(
+                    itemEntity.getName(), ItemCode.toCode(randomItemId), "이미 가지고 있어요.");
+        }
+
+        MemberItemEntity memberItemEntity = MemberItemEntity.obtainItem(memberEntity, itemEntity);
+        memberItemRepository.save(memberItemEntity);
+
+        return new DrawItemResponse(itemEntity.getName(), ItemCode.toCode(randomItemId), null);
+    }
+
+    private Long getRandomItemId() {
+        List<Long> itemIds = itemRepository.findAllItemIds();
+        ItemRandomFetcher itemRandomFetcher = new ItemRandomFetcher(itemIds);
+        Long randomItemId = itemRandomFetcher.generateRandomItem();
+        return randomItemId;
+    }
+}

--- a/api/src/main/java/com/dnd/sbooky/api/item/DrawItemUsecase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/DrawItemUsecase.java
@@ -42,15 +42,15 @@ public class DrawItemUsecase {
                         .findById(randomItemId)
                         .orElseThrow(() -> new ItemNotFoundException(ITEM_NOT_FOUND));
 
-        if (memberItemRepository.existsByMemberIdAndItemId(memberId, randomItemId)) {
-            return new DrawItemResponse(
-                    itemEntity.getName(), ItemCode.toCode(randomItemId), "이미 가지고 있어요.");
+        boolean isAlreadyOwned = memberItemRepository.existsByMemberIdAndItemId(memberId, randomItemId);
+
+        if (!isAlreadyOwned) {
+            MemberItemEntity memberItemEntity = MemberItemEntity.obtainItem(memberEntity, itemEntity);
+            memberItemRepository.save(memberItemEntity);
         }
 
-        MemberItemEntity memberItemEntity = MemberItemEntity.obtainItem(memberEntity, itemEntity);
-        memberItemRepository.save(memberItemEntity);
-
-        return new DrawItemResponse(itemEntity.getName(), ItemCode.toCode(randomItemId), null);
+        return DrawItemResponse.from(
+                itemEntity.getName(), ItemCode.toCode(randomItemId), isAlreadyOwned);
     }
 
     private Long getRandomItemId() {

--- a/api/src/main/java/com/dnd/sbooky/api/item/DrawItemUsecase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/DrawItemUsecase.java
@@ -15,7 +15,6 @@ import com.dnd.sbooky.core.item.MemberItemRepository;
 import com.dnd.sbooky.core.member.MemberEntity;
 import com.dnd.sbooky.core.member.MemberRepository;
 import com.dnd.sbooky.core.point.PointPolicy;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,6 +27,7 @@ public class DrawItemUsecase {
     private final ItemRepository itemRepository;
     private final MemberRepository memberRepository;
     private final MemberItemRepository memberItemRepository;
+    private final ItemRandomFetcher itemRandomFetcher;
 
     @Transactional
     public DrawItemResponse drawItem(Long memberId) {
@@ -54,8 +54,6 @@ public class DrawItemUsecase {
     }
 
     private Long getRandomItemId() {
-        List<Long> itemIds = itemRepository.findAllItemIds();
-        ItemRandomFetcher itemRandomFetcher = new ItemRandomFetcher(itemIds);
         Long randomItemId = itemRandomFetcher.generateRandomItem();
         return randomItemId;
     }

--- a/api/src/main/java/com/dnd/sbooky/api/item/response/DrawItemResponse.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/response/DrawItemResponse.java
@@ -7,7 +7,13 @@ public record DrawItemResponse(
         @Schema(description = "아이템 이름") String name,
         @Schema(description = "아이템 코드") String code,
         @Schema(description = "아이템 보유 시 메시지") String message) {
-    public static DrawItemResponse from(String name, String code, String message) {
-        return new DrawItemResponse(name, code, message);
+
+    public static final String ALREADY_OWNED_MESSAGE = "이미 보유 중입니다.";
+
+    public static DrawItemResponse from(String name, String code, boolean isAlreadyOwned) {
+        if (isAlreadyOwned) {
+            return new DrawItemResponse(name, code, ALREADY_OWNED_MESSAGE);
+        }
+        return new DrawItemResponse(name, code, null);
     }
 }

--- a/api/src/main/java/com/dnd/sbooky/api/item/response/DrawItemResponse.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/response/DrawItemResponse.java
@@ -1,0 +1,13 @@
+package com.dnd.sbooky.api.item.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "아이템 뽑기 응답 DTO")
+public record DrawItemResponse(
+        @Schema(description = "아이템 이름") String name,
+        @Schema(description = "아이템 코드") String code,
+        @Schema(description = "아이템 보유 시 메시지") String message) {
+    public static DrawItemResponse from(String name, String code, String message) {
+        return new DrawItemResponse(name, code, message);
+    }
+}

--- a/core/src/main/java/com/dnd/sbooky/core/Initializer.java
+++ b/core/src/main/java/com/dnd/sbooky/core/Initializer.java
@@ -30,6 +30,15 @@ public class Initializer {
         likeRepository.save(LikeEntity.newInstance(memberEntity.getId()));
         itemRepository.save(ItemEntity.newInstance(1L, ItemType.CHARACTER, "떠돌이 유령"));
         itemRepository.save(ItemEntity.newInstance(2L, ItemType.CHARACTER, "유령"));
+        itemRepository.save(ItemEntity.newInstance(3L, ItemType.CHARACTER, "고양이 유령"));
+        itemRepository.save(ItemEntity.newInstance(4L, ItemType.CHARACTER, "마법사 유령"));
+        itemRepository.save(ItemEntity.newInstance(5L, ItemType.CHARACTER, "명탐정 유령"));
+        itemRepository.save(ItemEntity.newInstance(6L, ItemType.CHARACTER, "어린왕자 유령"));
+        itemRepository.save(ItemEntity.newInstance(7L, ItemType.CHARACTER, "프랑켄슈타인 유령"));
+        itemRepository.save(ItemEntity.newInstance(8L, ItemType.CHARACTER, "빨간망토 유령"));
+        itemRepository.save(ItemEntity.newInstance(9L, ItemType.CHARACTER, "치즈 고양이 유령"));
+        itemRepository.save(ItemEntity.newInstance(10L, ItemType.CHARACTER, "샴 고양이 유령"));
+        itemRepository.save(ItemEntity.newInstance(11L, ItemType.CHARACTER, "백도 고양이 유령"));
 
         Arrays.stream(EvaluationKeyword.values())
                 .forEach(keyword -> evaluationRepository.save(EvaluationEntity.newInstance(keyword)));

--- a/core/src/main/java/com/dnd/sbooky/core/item/ItemCode.java
+++ b/core/src/main/java/com/dnd/sbooky/core/item/ItemCode.java
@@ -4,7 +4,16 @@ import java.util.Arrays;
 
 public enum ItemCode {
     MUMMY(1L, "mummy_ghost"),
-    BASIC(2L, "basic_ghost");
+    BASIC(2L, "basic_ghost"),
+    CAT(3L, "cat_ghost"),
+    WIZARD(4L, "wizard_ghost"),
+    DETECTIVE(5L, "detective_ghost"),
+    LITTLE_PRINCE(6L, "littleprince_ghost"),
+    FRANKENSTEIN(7L, "frankenstein_ghost"),
+    REDHOOD(8L, "redhood_ghost"),
+    CHEESE_CAT(9L, "cheese_cat_ghost"),
+    SIAMESE_CAT(10L, "siamese_cat_ghost"),
+    BAEKDO_CAT(11L, "baekdo_cat_ghost");
 
     private final Long id;
     private final String code;

--- a/core/src/main/java/com/dnd/sbooky/core/item/ItemEntity.java
+++ b/core/src/main/java/com/dnd/sbooky/core/item/ItemEntity.java
@@ -9,10 +9,12 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "item")
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ItemEntity extends BaseEntity {
 

--- a/core/src/main/java/com/dnd/sbooky/core/item/ItemRandomFetcher.java
+++ b/core/src/main/java/com/dnd/sbooky/core/item/ItemRandomFetcher.java
@@ -1,0 +1,16 @@
+package com.dnd.sbooky.core.item;
+
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class ItemRandomFetcher {
+    private final List<Long> itemIds;
+
+    public ItemRandomFetcher(List<Long> itemIds) {
+        this.itemIds = itemIds;
+    }
+
+    public Long generateRandomItem() {
+        return ThreadLocalRandom.current().nextLong(1, itemIds.size() + 1);
+    }
+}

--- a/core/src/main/java/com/dnd/sbooky/core/item/ItemRandomFetcher.java
+++ b/core/src/main/java/com/dnd/sbooky/core/item/ItemRandomFetcher.java
@@ -1,16 +1,17 @@
 package com.dnd.sbooky.core.item;
 
-import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
+import org.springframework.stereotype.Component;
 
+@Component
 public class ItemRandomFetcher {
-    private final List<Long> itemIds;
+    private final long ITEM_SIZE;
 
-    public ItemRandomFetcher(List<Long> itemIds) {
-        this.itemIds = itemIds;
+    public ItemRandomFetcher() {
+        this.ITEM_SIZE = ItemCode.values().length;
     }
 
     public Long generateRandomItem() {
-        return ThreadLocalRandom.current().nextLong(1, itemIds.size() + 1);
+        return ThreadLocalRandom.current().nextLong(1, ITEM_SIZE + 1);
     }
 }

--- a/core/src/main/java/com/dnd/sbooky/core/item/ItemRepository.java
+++ b/core/src/main/java/com/dnd/sbooky/core/item/ItemRepository.java
@@ -1,5 +1,11 @@
 package com.dnd.sbooky.core.item;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
-public interface ItemRepository extends JpaRepository<ItemEntity, Long> {}
+public interface ItemRepository extends JpaRepository<ItemEntity, Long> {
+
+    @Query("select i.id from ItemEntity i")
+    List<Long> findAllItemIds();
+}


### PR DESCRIPTION
## 연관된 이슈

closes #65 

## 작업 내용

아이템을 랜덤으로 뽑는 기능을 구현하였습니다.
이이템 랜덤 뽑기 후 뽑힌 아이템이 이미 보유 중인 아이템일 때, 아래와 같은 응답을 반환합니다.

![스크린샷 2025-02-18 오후 7 02 25](https://github.com/user-attachments/assets/756ab1a3-dcae-4bf6-a1e4-b25b2050e30b)

이이템 랜덤 뽑기 후 뽑힌 아이템이 이미 보유 중인 아이템이 아닐 경우, 아래와 같은 응답을 반환합니다.

![스크린샷 2025-02-18 오후 7 02 09](https://github.com/user-attachments/assets/c6547fa4-13f5-477b-b663-192cac6234ff)


## 리뷰 요구사항

포인트가 없을 경우 Core 모듈의 Point 엔티티에서 예외를 발생시키는 데 이에 대한 핸들링이 필요합니다.
관련해서 논의해보면 좋을 거 같습니다.

기존에 구현되어있는 accumulatePointUseCase의 accumulate 메서드를 사용해서 포인트를 사용하는 것을 구현하였는데  "포인트를 소비하는 것"이 드러나지 않는 듯 해보입니다. 