### PR TITLE
보유 포인트를 조회한다.

### DIFF
--- a/api/src/main/java/com/dnd/sbooky/api/docs/spec/GetPointApiSpec.java
+++ b/api/src/main/java/com/dnd/sbooky/api/docs/spec/GetPointApiSpec.java
@@ -1,0 +1,16 @@
+package com.dnd.sbooky.api.docs.spec;
+
+import com.dnd.sbooky.api.point.response.GetPointResponse;
+import com.dnd.sbooky.api.support.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@Tag(name = "[Point API]", description = "포인트에 관련된 API")
+@SecurityRequirement(name = "access-token")
+public interface GetPointApiSpec {
+
+    @Operation(summary = "포인트 및 뽑기 정보 조회", description = "회원이 포인트 및 뽑기 정보를 조회한다.")
+    ApiResponse<GetPointResponse> getPoint(UserDetails user);
+}

--- a/api/src/main/java/com/dnd/sbooky/api/point/GetPointController.java
+++ b/api/src/main/java/com/dnd/sbooky/api/point/GetPointController.java
@@ -1,0 +1,29 @@
+package com.dnd.sbooky.api.point;
+
+import com.dnd.sbooky.api.docs.spec.GetPointApiSpec;
+import com.dnd.sbooky.api.point.response.GetPointResponse;
+import com.dnd.sbooky.api.support.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class GetPointController implements GetPointApiSpec {
+
+    private final GetPointUseCase getPointUseCase;
+
+    @GetMapping("/members/point")
+    public ApiResponse<GetPointResponse> getPoint(
+            @Parameter(hidden = true) @AuthenticationPrincipal UserDetails user) {
+
+        // fixme : 해당 패키지 위치가 맞는가?
+        Long memberId = Long.valueOf(user.getUsername());
+        return ApiResponse.success(getPointUseCase.get(memberId));
+    }
+}

--- a/api/src/main/java/com/dnd/sbooky/api/point/GetPointUseCase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/point/GetPointUseCase.java
@@ -1,0 +1,28 @@
+package com.dnd.sbooky.api.point;
+
+import com.dnd.sbooky.api.member.exception.MemberNotFoundException;
+import com.dnd.sbooky.api.point.response.GetPointResponse;
+import com.dnd.sbooky.api.support.error.ErrorType;
+import com.dnd.sbooky.core.member.MemberRepository;
+import com.dnd.sbooky.core.point.PointRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class GetPointUseCase {
+
+    private final PointRepository pointRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional(readOnly = true)
+    public GetPointResponse get(Long memberId) {
+
+        if (!memberRepository.existsById(memberId)) {
+            throw new MemberNotFoundException(ErrorType.MEMBER_NOT_FOUND);
+        }
+
+        return GetPointResponse.from(pointRepository.findCurrentPointByMemberId(memberId));
+    }
+}

--- a/api/src/main/java/com/dnd/sbooky/api/point/response/GetPointResponse.java
+++ b/api/src/main/java/com/dnd/sbooky/api/point/response/GetPointResponse.java
@@ -1,0 +1,19 @@
+package com.dnd.sbooky.api.point.response;
+
+import com.dnd.sbooky.core.point.PointPolicy;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "포인트 및 뽑기 정보 조회 응답")
+public record GetPointResponse(
+        @Schema(description = "보유 포인트") int point,
+        @Schema(description = "뽑기 가능 횟수") int drawCount,
+        @Schema(description = "뽑기 1회 소모 포인트") int drawPoint) {
+
+    public static GetPointResponse from(int point) {
+
+        int drawPoint = Math.abs(PointPolicy.DRAW_ITEM.getPoint());
+        int drawCount = point / drawPoint;
+
+        return new GetPointResponse(point, drawCount, drawPoint);
+    }
+}


### PR DESCRIPTION
## 연관된 이슈

resolves #120 

## 작업 내용

보유 포인트 조회 API 를 구현했습니다. 

_응답 예시_
```json
{
    "resultType": "SUCCESS",
    "data": {
        "point": 110,
        "drawCount": 1,
        "drawPoint": 100
    },
    "error": null
}
```

> 응답에 '포인트'만 존재하는게 아니라서 애매하긴 하지만,,,

## 리뷰 요구사항

추후에 패키지 구조에 대해서 한 번 의논하기! 👀