### PR TITLE
FeignClient 타임아웃과 재시도 설정을 조정한다.

### DIFF
--- a/api/src/main/java/com/dnd/sbooky/api/security/TokenConstants.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/TokenConstants.java
@@ -4,7 +4,9 @@ public class TokenConstants {
     public static final String TOKEN_PREFIX = "Bearer ";
     public static final String REFRESH_TOKEN = "refreshToken";
 
-    public static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30L; // 30 minutes
+    // fixme : ACCESS TOKEN EXPIRE TIME 변경해야함!!
+//    public static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30L; // 30 minutes
+    public static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7L; // 임시로 7일 설정
 
     public static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 14L; // 14 days
 

--- a/api/src/main/java/com/dnd/sbooky/api/security/TokenConstants.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/TokenConstants.java
@@ -5,7 +5,7 @@ public class TokenConstants {
     public static final String REFRESH_TOKEN = "refreshToken";
 
     // fixme : ACCESS TOKEN EXPIRE TIME 변경해야함!!
-//    public static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30L; // 30 minutes
+    //    public static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30L; // 30 minutes
     public static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7L; // 임시로 7일 설정
 
     public static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 14L; // 14 days

--- a/clients/src/main/java/com/dnd/sbooky/clients/config/FeignClientConfig.java
+++ b/clients/src/main/java/com/dnd/sbooky/clients/config/FeignClientConfig.java
@@ -13,11 +13,11 @@ import org.springframework.context.annotation.Profile;
 @EnableFeignClients(basePackages = "com.dnd.sbooky.clients")
 class FeignClientConfig {
 
-    private static final long CONNECT_TIMEOUT_MILLIS = 5000L;
-    private static final long READ_TIMEOUT_MILLIS = 5000L;
+    private static final long CONNECT_TIMEOUT_MILLIS = 1000L;
+    private static final long READ_TIMEOUT_MILLIS = 1000L;
 
-    private static final long RETRY_PERIOD = 100L;
-    private static final long RETRY_MAX_PERIOD = 2000L;
+    private static final long RETRY_PERIOD = 50L;
+    private static final long RETRY_MAX_PERIOD = 500L;
     private static final int RETRY_MAX_ATTEMPTS = 3;
 
     /**

--- a/clients/src/main/java/com/dnd/sbooky/clients/config/FeignClientConfig.java
+++ b/clients/src/main/java/com/dnd/sbooky/clients/config/FeignClientConfig.java
@@ -61,11 +61,11 @@ class FeignClientConfig {
     /**
      * FeignClient 로깅 설정
      * <p>
-     * 운영 환경(prod)을 제외한 모든 환경에서 기본(BASIC) 레벨의 로깅을 활성화합니다.
+     *     로컬 환경에서만 로깅 레벨을 BASIC 으로 설정합니다.
      *
      * @return Logger.Level 로깅 레벨
      */
-    @Profile("!prod")
+    @Profile("local")
     @Bean
     Logger.Level feignLoggerLevel() {
         return Logger.Level.BASIC;


### PR DESCRIPTION
## 연관된 이슈

resolves #125 

## 작업 내용

타임아웃 설정

- Connection Timeout: 5000ms -> 1000ms
- Read Timeout: 5000ms -> 1000ms

재시도 설정

- Retry Period: 100ms -> 50ms
- Retry Max Period: 2000ms -> 500ms

로깅 설정
- local 환경에서만 작동

## 리뷰 요구사항

> 개발 환경에서 500회 이상 호출 데이터를 기반으로 평균을 내봤을 때 다음과 같습니다.

**평균 응답 시간: 31.2ms**

세부 내역:

- 최소 응답 시간: 18ms
- 최대 응답 시간: 214ms

대부분의 요청이 20-40ms 사이에 분포

이러한 데이터를 기준으로, 조금 넉넉하게 타임아웃 설정과 재시도를 설정했는데 더 빡빡하게 설정을 해야할까요? 