### PR TITLE
지금까지 완독한 책의 수를 조회한다.

### DIFF
--- a/api/src/main/java/com/dnd/sbooky/api/book/FindBookController.java
+++ b/api/src/main/java/com/dnd/sbooky/api/book/FindBookController.java
@@ -2,6 +2,7 @@ package com.dnd.sbooky.api.book;
 
 import com.dnd.sbooky.api.book.response.FindAllBookResponse;
 import com.dnd.sbooky.api.book.response.FindBookDetailsResponse;
+import com.dnd.sbooky.api.book.response.FindCompletedBookResponse;
 import com.dnd.sbooky.api.docs.spec.FindBookApiSpec;
 import com.dnd.sbooky.api.support.response.ApiResponse;
 import com.dnd.sbooky.core.book.ReadStatus;
@@ -45,6 +46,18 @@ public class FindBookController implements FindBookApiSpec {
 
         return ApiResponse.success(
                 findBookUseCase.findAllMemberBooks(currentMemberId, memberId, readStatus));
+    }
+
+    /**
+     * 주인이 등록한 책 중 완독한 도서의 수를 조회한다.
+     */
+    @GetMapping("/books/members/{memberId}/completed")
+    public ApiResponse<FindCompletedBookResponse> findCompletedBooks(
+            @PathVariable Long memberId,
+            @Parameter(hidden = true) @AuthenticationPrincipal UserDetails user) {
+
+        Long currentMemberId = extractMemberId(user);
+        return ApiResponse.success(findBookUseCase.findCompletedBooks(currentMemberId, memberId));
     }
 
     /**

--- a/api/src/main/java/com/dnd/sbooky/api/book/FindBookUseCase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/book/FindBookUseCase.java
@@ -4,6 +4,7 @@ import com.dnd.sbooky.api.book.exception.BookForbiddenException;
 import com.dnd.sbooky.api.book.exception.BookNotFoundException;
 import com.dnd.sbooky.api.book.response.FindAllBookResponse;
 import com.dnd.sbooky.api.book.response.FindBookDetailsResponse;
+import com.dnd.sbooky.api.book.response.FindCompletedBookResponse;
 import com.dnd.sbooky.api.member.exception.MemberNotFoundException;
 import com.dnd.sbooky.api.support.error.ErrorType;
 import com.dnd.sbooky.core.book.MemberBookEntity;
@@ -50,6 +51,19 @@ public class FindBookUseCase {
         }
 
         return FindBookDetailsResponse.of(memberBookRepository.findBookDetails(memberBookId));
+    }
+
+    @Transactional(readOnly = true)
+    public FindCompletedBookResponse findCompletedBooks(Long currentMemberId, Long memberId) {
+
+        MemberEntity member =
+                memberRepository
+                        .findById(memberId)
+                        .orElseThrow(() -> new MemberNotFoundException(ErrorType.MEMBER_NOT_FOUND));
+
+        validateBookAccess(member, memberId, currentMemberId);
+
+        return FindCompletedBookResponse.of(memberBookRepository.findCompletedBooks(memberId));
     }
 
     private void validateBookAccess(MemberEntity member, Long targetMemberId, Long currentMemberId) {

--- a/api/src/main/java/com/dnd/sbooky/api/book/response/FindCompletedBookResponse.java
+++ b/api/src/main/java/com/dnd/sbooky/api/book/response/FindCompletedBookResponse.java
@@ -1,0 +1,8 @@
+package com.dnd.sbooky.api.book.response;
+
+public record FindCompletedBookResponse(long completedBookCount) {
+
+    public static FindCompletedBookResponse of(long completedBookCount) {
+        return new FindCompletedBookResponse(completedBookCount);
+    }
+}

--- a/api/src/main/java/com/dnd/sbooky/api/docs/spec/FindBookApiSpec.java
+++ b/api/src/main/java/com/dnd/sbooky/api/docs/spec/FindBookApiSpec.java
@@ -2,6 +2,7 @@ package com.dnd.sbooky.api.docs.spec;
 
 import com.dnd.sbooky.api.book.response.FindAllBookResponse;
 import com.dnd.sbooky.api.book.response.FindBookDetailsResponse;
+import com.dnd.sbooky.api.book.response.FindCompletedBookResponse;
 import com.dnd.sbooky.api.support.response.ApiResponse;
 import com.dnd.sbooky.core.book.ReadStatus;
 import io.swagger.v3.oas.annotations.Operation;
@@ -19,4 +20,7 @@ public interface FindBookApiSpec {
 
     @Operation(summary = "책 상세 조회", description = "도서의 상세 정보를 조회한다.")
     ApiResponse<FindBookDetailsResponse> findBookDetails(Long memberBookId);
+
+    @Operation(summary = "책장 주인 완독 도서 개수 조회", description = "주인이 등록한 책 중 완독한 도서의 개수를 조회한다.")
+    ApiResponse<FindCompletedBookResponse> findCompletedBooks(Long memberId, UserDetails user);
 }

--- a/core/src/main/java/com/dnd/sbooky/core/book/MemberBookRepositoryCustom.java
+++ b/core/src/main/java/com/dnd/sbooky/core/book/MemberBookRepositoryCustom.java
@@ -13,4 +13,6 @@ public interface MemberBookRepositoryCustom {
     FindBookDetailsDTO findBookDetails(Long memberBookId);
 
     boolean checkBookExist(Long memberId, String title, String author);
+
+    long findCompletedBooks(Long memberId);
 }

--- a/core/src/main/java/com/dnd/sbooky/core/book/MemberBookRepositoryImpl.java
+++ b/core/src/main/java/com/dnd/sbooky/core/book/MemberBookRepositoryImpl.java
@@ -71,6 +71,15 @@ public class MemberBookRepositoryImpl implements MemberBookRepositoryCustom {
                 != null;
     }
 
+    @Override
+    public long findCompletedBooks(Long memberId) {
+        return queryFactory
+                .select(memberBook.count())
+                .from(memberBook)
+                .where(memberBook.memberEntity.id.eq(memberId), readStatusEqual(ReadStatus.COMPLETED))
+                .fetchOne();
+    }
+
     private BooleanExpression hasBook(Long memberId, String title, String author) {
         return member.id.eq(memberId).and(book.title.eq(title)).and(book.author.eq(author));
     }


### PR DESCRIPTION
## 연관된 이슈

resolves #126 

## 작업 내용

홈 화면에서 필요한, 완독한 책의 수 조회 API를 구현했습니다. 

```json
{
    "resultType": "SUCCESS",
    "data": {
        "completedBookCount": 2 // 완독한 책의 수 
    },
    "error": null
}
```

## 리뷰 요구사항

조회를 날리기 위해 작성한 쿼리 구현 부분(Querydsl)에서 `Long` 타입으로 반환을 해주다보니 Intellij 상에서 노란줄이 나오더라구요

이러한 상황에서 대선님은 주로 어떻게 반환하시나요?
