### PR TITLE
좋아요 엔티티 구조를 변경한다.

### DIFF
--- a/api/src/main/java/com/dnd/sbooky/api/like/AddLikeController.java
+++ b/api/src/main/java/com/dnd/sbooky/api/like/AddLikeController.java
@@ -19,6 +19,7 @@ public class AddLikeController implements AddLikeApiSpec {
 
     @PatchMapping("/likes")
     public ApiResponse<?> addLikes(@Valid @RequestBody AddLikeRequest request) {
-        return ApiResponse.success(addLikeUsecase.add(request.memberId(), request.addCount()));
+        addLikeUsecase.add(request.memberId(), request.addCount());
+        return ApiResponse.success();
     }
 }

--- a/api/src/main/java/com/dnd/sbooky/api/like/AddLikeUsecase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/like/AddLikeUsecase.java
@@ -1,9 +1,12 @@
 package com.dnd.sbooky.api.like;
 
+import static com.dnd.sbooky.api.support.error.ErrorType.*;
+
 import com.dnd.sbooky.api.member.exception.MemberNotFoundException;
-import com.dnd.sbooky.api.support.error.ErrorType;
 import com.dnd.sbooky.core.like.LikeEntity;
 import com.dnd.sbooky.core.like.LikeRepository;
+import com.dnd.sbooky.core.member.MemberEntity;
+import com.dnd.sbooky.core.member.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,12 +17,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class AddLikeUsecase {
 
     private final LikeRepository likeRepository;
+    private final MemberRepository memberRepository;
 
-    public Long add(Long memberId, Long addCount) {
-        LikeEntity likeEntity =
-                likeRepository
-                        .findByIdWithPessimisticLock(memberId)
-                        .orElseThrow(() -> new MemberNotFoundException(ErrorType.MEMBER_NOT_FOUND));
-        return likeEntity.add(addCount);
+    public void add(Long memberId, Long addCount) {
+        MemberEntity memberEntity =
+                memberRepository
+                        .findById(memberId)
+                        .orElseThrow(() -> new MemberNotFoundException(MEMBER_NOT_FOUND));
+        likeRepository.saveAll(LikeEntity.newInstances(memberEntity, addCount));
     }
 }

--- a/api/src/main/java/com/dnd/sbooky/api/like/GetLikesUsecase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/like/GetLikesUsecase.java
@@ -2,8 +2,8 @@ package com.dnd.sbooky.api.like;
 
 import com.dnd.sbooky.api.member.exception.MemberNotFoundException;
 import com.dnd.sbooky.api.support.error.ErrorType;
-import com.dnd.sbooky.core.like.LikeEntity;
 import com.dnd.sbooky.core.like.LikeRepository;
+import com.dnd.sbooky.core.member.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,13 +12,17 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class GetLikesUsecase {
     private final LikeRepository likeRepository;
+    private final MemberRepository memberRepository;
 
     @Transactional(readOnly = true)
     public Long get(Long memberId) {
-        LikeEntity likeEntity =
-                likeRepository
-                        .findById(memberId)
-                        .orElseThrow(() -> new MemberNotFoundException(ErrorType.MEMBER_NOT_FOUND));
-        return likeEntity.getCount();
+        validateMember(memberId);
+        return likeRepository.countByMemberEntityId(memberId);
+    }
+
+    private void validateMember(Long memberId) {
+        if (!memberRepository.existsById(memberId)) {
+            throw new MemberNotFoundException(ErrorType.MEMBER_NOT_FOUND);
+        }
     }
 }

--- a/api/src/main/java/com/dnd/sbooky/api/security/CustomOAuth2UserService.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/CustomOAuth2UserService.java
@@ -64,7 +64,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                 .orElseGet(
                         () -> {
                             MemberEntity savedMember = memberRepository.save(oAuth2UserDTO.toEntity());
-                            likeRepository.save(LikeEntity.newInstance(savedMember.getId()));
+                            likeRepository.save(LikeEntity.newInstance(savedMember));
                             ItemEntity itemEntity =
                                     itemRepository
                                             .findById(1L)

--- a/core/src/main/java/com/dnd/sbooky/core/like/LikeEntity.java
+++ b/core/src/main/java/com/dnd/sbooky/core/like/LikeEntity.java
@@ -1,33 +1,30 @@
 package com.dnd.sbooky.core.like;
 
+import com.dnd.sbooky.core.member.MemberEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "likes")
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Getter
 public class LikeEntity {
     private static final String ENTITY_PREFIX = "likes";
-    private static final long START_COUNT = 0L;
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = ENTITY_PREFIX + "_id")
     private Long id;
 
-    @Column(name = ENTITY_PREFIX + "_count")
-    private Long count;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private MemberEntity memberEntity;
 
-    public static LikeEntity newInstance(Long likeId) {
-        return new LikeEntity(likeId, START_COUNT);
+    private LikeEntity(MemberEntity memberEntity) {
+        this.memberEntity = memberEntity;
     }
 
-    public Long add(long count) {
-        this.count += count;
-        return this.count;
+    public static LikeEntity newInstance(MemberEntity memberEntity) {
+        return new LikeEntity(memberEntity);
     }
 }

--- a/core/src/main/java/com/dnd/sbooky/core/like/LikeEntity.java
+++ b/core/src/main/java/com/dnd/sbooky/core/like/LikeEntity.java
@@ -2,6 +2,8 @@ package com.dnd.sbooky.core.like;
 
 import com.dnd.sbooky.core.member.MemberEntity;
 import jakarta.persistence.*;
+import java.util.List;
+import java.util.stream.LongStream;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -26,5 +28,9 @@ public class LikeEntity {
 
     public static LikeEntity newInstance(MemberEntity memberEntity) {
         return new LikeEntity(memberEntity);
+    }
+
+    public static List<LikeEntity> newInstances(MemberEntity memberEntity, long count) {
+        return LongStream.range(0, count).mapToObj(i -> new LikeEntity(memberEntity)).toList();
     }
 }

--- a/core/src/main/java/com/dnd/sbooky/core/like/LikeRepository.java
+++ b/core/src/main/java/com/dnd/sbooky/core/like/LikeRepository.java
@@ -12,4 +12,6 @@ public interface LikeRepository extends JpaRepository<LikeEntity, Long> {
     @LockTimeout
     @Query("select l from LikeEntity l where l.id = :id")
     Optional<LikeEntity> findByIdWithPessimisticLock(Long id);
+
+    Long countByMemberEntityId(Long memberId);
 }


### PR DESCRIPTION
## 연관된 이슈

closes #131 

## 작업 내용

동시성 문제를 회피하기 위해, 회원의 좋아요 수를 업데이트하는 방식에서 좋아요 1개당 하나의 행을 삽입하는 방식으로 변경하였으며, 이에 따라 좋아요 엔티티를 다음과 같이 수정하였습니다.

```java
@Entity
@Table(name = "likes")
@NoArgsConstructor(access = AccessLevel.PROTECTED)
public class LikeEntity {
    private static final String ENTITY_PREFIX = "likes";

    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    @Column(name = ENTITY_PREFIX + "_id")
    private Long id;

    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "member_id", nullable = false)
    private MemberEntity memberEntity;
```

## 리뷰 요구사항

좋아요 누르기 API 호출 시 addCount가 1개 이상일 수 있어 saveAll() 메서드를 사용하였습니다.

Bulk insert도 고려했지만, 프론트엔드에서 일정 단위로 측정한 좋아요 수가 몇 개일지 확실하지 않아 우선 saveAll()을 적용했습니다.

추후 프론트엔드 팀과 논의하여 API 호출 시 아래의 방법 중 어떤 방법이 더 적절한 지 논의해볼 예정입니다.

1. 한 번 호출할 때마다 좋아요 수를 무조건 +1 증가시키는 방식
2. 프론트에서 일정 단위로 측정한 좋아요 수를 한 번에 전달하는 방식
