### PR TITLE
책 등록시 이미지 URL도 함께 받는다.

### DIFF
--- a/api/src/main/java/com/dnd/sbooky/api/book/RegisterBookUseCase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/book/RegisterBookUseCase.java
@@ -31,9 +31,11 @@ public class RegisterBookUseCase {
                         .findById(memberId)
                         .orElseThrow(() -> new MemberNotFoundException(ErrorType.MEMBER_NOT_FOUND));
 
+        // fixme: 문제 발생 지점.. 처음에 등록한 책 정보를 기반으로 썸네일이 없을 수도 있음..
         BookEntity book =
                 bookRepository
-                        .findByAuthorAndTitle(request.author(), request.title())
+                        .findByAuthorAndTitleAndThumbnailUrl(
+                                request.author(), request.title(), request.thumbnailUrl())
                         .orElseGet(() -> bookRepository.save(createBook(request)));
 
         memberBookRepository.save(
@@ -43,7 +45,8 @@ public class RegisterBookUseCase {
     }
 
     private BookEntity createBook(RegisterBookRequest request) {
-        return BookEntity.newInstance(request.author(), request.title(), request.publishedAt());
+        return BookEntity.newInstance(
+                request.author(), request.title(), request.publishedAt(), request.thumbnailUrl());
     }
 
     private MemberBookEntity createMemberBook(

--- a/api/src/main/java/com/dnd/sbooky/api/book/request/RegisterBookRequest.java
+++ b/api/src/main/java/com/dnd/sbooky/api/book/request/RegisterBookRequest.java
@@ -4,11 +4,13 @@ import com.dnd.sbooky.api.common.Enum;
 import com.dnd.sbooky.core.book.ReadStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import java.time.LocalDate;
 import org.springframework.format.annotation.DateTimeFormat;
 
 @Schema(description = "책 등록 요청 DTO")
 public record RegisterBookRequest(
+        // @formatter:off
         @Schema(description = "책 제목") @NotBlank String title,
         @Schema(description = "저자") @NotBlank String author,
         @Schema(description = "출판일") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate publishedAt,
@@ -16,4 +18,10 @@ public record RegisterBookRequest(
                         description = "읽은 상태",
                         allowableValues = {"WANT_TO_READ", "READING", "COMPLETED"})
                 @Enum(enumClass = ReadStatus.class)
-                String readStatus) {}
+                String readStatus,
+        @Schema(description = "썸네일 URL")
+                @Pattern(regexp = "^$|^(http|https)://.*", message = "http 또는 https로 시작하는 URL을 입력해주세요.")
+                String thumbnailUrl) {
+
+    // @formatter:on
+}

--- a/core/src/main/java/com/dnd/sbooky/core/book/BookEntity.java
+++ b/core/src/main/java/com/dnd/sbooky/core/book/BookEntity.java
@@ -31,7 +31,6 @@ public class BookEntity extends BaseEntity {
     private LocalDate publishedAt;
 
     @Column(name = ENTITY_PREFIX + "_thumbnail_url")
-    // todo : nullable = false
     private String thumbnailUrl;
 
     @Builder
@@ -42,8 +41,15 @@ public class BookEntity extends BaseEntity {
         this.thumbnailUrl = thumbnailUrl;
     }
 
-    public static BookEntity newInstance(String author, String title, LocalDate publishedAt) {
-        return BookEntity.builder().author(author).title(title).publishedAt(publishedAt).build();
+    public static BookEntity newInstance(
+            String author, String title, LocalDate publishedAt, String thumbnailUrl) {
+
+        return BookEntity.builder()
+                .author(author)
+                .title(title)
+                .publishedAt(publishedAt)
+                .thumbnailUrl(thumbnailUrl)
+                .build();
     }
 
     public void update(String author, String title, LocalDate localDate) {

--- a/core/src/main/java/com/dnd/sbooky/core/book/BookRepository.java
+++ b/core/src/main/java/com/dnd/sbooky/core/book/BookRepository.java
@@ -5,5 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BookRepository extends JpaRepository<BookEntity, Long> {
 
-    Optional<BookEntity> findByAuthorAndTitle(String author, String title);
+    Optional<BookEntity> findByAuthorAndTitleAndThumbnailUrl(
+            String author, String title, String thumbnailUrl);
 }


### PR DESCRIPTION
## 연관된 이슈

resolves #137 

## 작업 내용

책 등록 로직에서 이미지 URL도 함께 저장하는 방식으로 변경했습니다. 

## 리뷰 요구사항

큰 문제 상황은 아니지만, 하나의 문제가 있더라구요

기존에 같은 책을 구별하는 기준을 '책 제목 + 저자 이름' 으로 하다보니, 다음과 같은 문제점이 발생해요 

1. 1번 사용자가 '소년이 온다, 한강' 의 책 썸네일이 **공백인 것** 을 선택해서 저장함
2. 2번 사용자는 '소년이 온다, 한강'의 책 썸네일이 **표지가 있는 것** 을 선택해서 저장하려고 했으나
   &rarr; 기존 책이 존재하므로, 썸네일이 없는 버전으로 저장되는 문제 발생
3. 결과적으로 2번 사용자가 의도한 것과 다르게 썸네일이 없는 버전으로 저장됨

이러한 상황을 해결하기 위해 같은 책을 구별하는 기준을 **'책 제목 + 저자 이름 + 썸네일 URL'** 3개가 동일한지 체크하는 방식으로 변경했어요.

이렇게 하면 사용자가 선택한 썸네일 버전 그대로 저장될 수 있습니다.

> 더 좋은 방법이 있다면, 추후에 이야기해보고 변경하면 좋을 것 같아요! 