### PR TITLE
온보딩을 했을 때 기본 코스트를 착용한다.

### DIFF
--- a/api/src/main/java/com/dnd/sbooky/api/item/SwitchEquippedItemController.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/SwitchEquippedItemController.java
@@ -25,7 +25,7 @@ public class SwitchEquippedItemController implements SwitchEquippedItemApiSpec {
             @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails,
             @Valid @RequestBody SwitchEquippedItemRequest request) {
         Long memberId = Long.parseLong(userDetails.getUsername());
-        switchEquippedItemUsecase.switchEquippedItem(memberId, request);
+        switchEquippedItemUsecase.switchEquippedItem(memberId, request.equippedItemCode(), request.toEquipItemCode());
         return ApiResponse.success();
     }
 }

--- a/api/src/main/java/com/dnd/sbooky/api/item/SwitchEquippedItemController.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/SwitchEquippedItemController.java
@@ -25,7 +25,8 @@ public class SwitchEquippedItemController implements SwitchEquippedItemApiSpec {
             @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails,
             @Valid @RequestBody SwitchEquippedItemRequest request) {
         Long memberId = Long.parseLong(userDetails.getUsername());
-        switchEquippedItemUsecase.switchEquippedItem(memberId, request.equippedItemCode(), request.toEquipItemCode());
+        switchEquippedItemUsecase.switchEquippedItem(
+                memberId, request.equippedItemCode(), request.toEquipItemCode());
         return ApiResponse.success();
     }
 }

--- a/api/src/main/java/com/dnd/sbooky/api/item/SwitchEquippedItemUsecase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/SwitchEquippedItemUsecase.java
@@ -3,7 +3,6 @@ package com.dnd.sbooky.api.item;
 import static com.dnd.sbooky.api.support.error.ErrorType.*;
 
 import com.dnd.sbooky.api.item.exception.MemberHasNotItemException;
-import com.dnd.sbooky.api.item.request.SwitchEquippedItemRequest;
 import com.dnd.sbooky.core.item.ItemCode;
 import com.dnd.sbooky.core.item.MemberItemEntity;
 import com.dnd.sbooky.core.item.MemberItemRepository;

--- a/api/src/main/java/com/dnd/sbooky/api/item/SwitchEquippedItemUsecase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/SwitchEquippedItemUsecase.java
@@ -18,9 +18,9 @@ public class SwitchEquippedItemUsecase {
 
     private final MemberItemRepository memberItemRepository;
 
-    public void switchEquippedItem(Long memberId, SwitchEquippedItemRequest request) {
-        unEquipItem(memberId, ItemCode.toId(request.equippedItemCode()));
-        equipItem(memberId, ItemCode.toId(request.toEquipItemCode()));
+    public void switchEquippedItem(Long memberId, String equippedItemCode, String toEquipItemCode) {
+        unEquipItem(memberId, ItemCode.toId(equippedItemCode));
+        equipItem(memberId, ItemCode.toId(toEquipItemCode));
     }
 
     private void unEquipItem(Long memberId, Long equippedItemId) {

--- a/api/src/main/java/com/dnd/sbooky/api/member/PerformOnboardingUseCase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/member/PerformOnboardingUseCase.java
@@ -3,6 +3,7 @@ package com.dnd.sbooky.api.member;
 import static com.dnd.sbooky.api.support.error.ErrorType.MEMBER_NOT_FOUND;
 
 import com.dnd.sbooky.api.item.ObtainItemUseCase;
+import com.dnd.sbooky.api.item.SwitchEquippedItemUsecase;
 import com.dnd.sbooky.api.member.exception.MemberNotFoundException;
 import com.dnd.sbooky.api.member.request.PerformOnboardingRequest;
 import com.dnd.sbooky.core.item.ItemCode;
@@ -18,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class PerformOnboardingUseCase {
     private final MemberRepository memberRepository;
     private final ObtainItemUseCase obtainItemUseCase;
+    private final SwitchEquippedItemUsecase switchEquippedItemUsecase;
 
     public void performOnboarding(Long memberId, PerformOnboardingRequest request) {
         MemberEntity member =
@@ -26,5 +28,7 @@ public class PerformOnboardingUseCase {
                         .orElseThrow(() -> new MemberNotFoundException(MEMBER_NOT_FOUND));
         member.updateNickname(request.nickname());
         obtainItemUseCase.obtainItem(memberId, ItemCode.BASIC.getId());
+        switchEquippedItemUsecase.switchEquippedItem(
+                memberId, ItemCode.MUMMY.getCode(), ItemCode.BASIC.getCode());
     }
 }

--- a/core/src/main/java/com/dnd/sbooky/core/item/ItemCode.java
+++ b/core/src/main/java/com/dnd/sbooky/core/item/ItemCode.java
@@ -49,4 +49,8 @@ public enum ItemCode {
     public Long getId() {
         return id;
     }
+
+    public String getCode() {
+        return code;
+    }
 }


### PR DESCRIPTION
## 연관된 이슈

closes #140 

## 작업 내용

기존에는 온보딩을 했을 때 "기본 고스트"를 얻기만 하는데, "기본 고스트"를 얻고 착용하는 것으로 수정한다.

## 리뷰 요구사항

온보딩 유스케이스)

```java
public void performOnboarding(Long memberId, PerformOnboardingRequest request) {
        MemberEntity member =
                memberRepository
                        .findById(memberId)
                        .orElseThrow(() -> new MemberNotFoundException(MEMBER_NOT_FOUND));
        member.updateNickname(request.nickname());
        obtainItemUseCase.obtainItem(memberId, ItemCode.BASIC.getId());
        switchEquippedItemUsecase.switchEquippedItem(
                memberId, ItemCode.MUMMY.getCode(), ItemCode.BASIC.getCode());
}
```

현재 정책에 따라 회원가입 시 MUMMY 아이템을 지급하고, 온보딩 시 BASIC 아이템을 얻도록 구현했습니다.

이번 PR에서는 기존에 착용 중인 아이템을 별도로 조회하지 않고, MUMMY에서 BASIC으로 바로 변경하는 방식으로 처리했습니다. 다만, 온보딩 시 지급되는 아이템이 변경되거나, 회원가입 시 지급되는 아이템이 달라질 경우 해당 코드도 수정이 필요할 것으로 보입니다.

이러한 점을 고려했을 때, 유지보수성을 높일 수 있는 방향이 어떤 게 있을까요??