### PR TITLE
책 검색 응답에 작가가 없는 경우 공백으로 응답한다.

### DIFF
--- a/api/src/main/java/com/dnd/sbooky/api/book/response/SearchBookResponse.java
+++ b/api/src/main/java/com/dnd/sbooky/api/book/response/SearchBookResponse.java
@@ -20,7 +20,7 @@ public record SearchBookResponse(
         List<Book> books = dto.documents().stream()
                               .map(document -> new Book(
                                       document.title(),
-                                      document.authors().get(0),
+                                      document.authors().isEmpty() ? "" : document.authors().get(0),
                                       document.datetime() == null
                                               ? LocalDate.EPOCH : document.datetime().toLocalDate(),
                                       document.extractThumbnailFileName())


### PR DESCRIPTION
## 연관된 이슈

resolves #143 

## 작업 내용

책 검색 응답에서 작가가 없는 경우에 `공백("")` 으로 응답하도록 수정했습니다. 

_변경 전 (배포 환경)_

<img width="1261" alt="image" src="https://github.com/user-attachments/assets/25d25fed-8078-489f-b9ca-e314782546ac" />


_변경 후 (로컬 환경)_

<img width="1261" alt="image" src="https://github.com/user-attachments/assets/83f5381d-7e3c-435a-a113-b7f28fdaa71b" />


## 리뷰 요구사항

