### PR TITLE
카카오 로그인 실패했을 경우 다시 로그인 페이지로 리다이렉트한다. 

### DIFF
--- a/api/src/main/java/com/dnd/sbooky/api/security/OAuth2FailureHandler.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/OAuth2FailureHandler.java
@@ -1,0 +1,26 @@
+package com.dnd.sbooky.api.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    @Value("${login.redirect-uri.failure}")
+    private String redirectUri;
+
+    @Override
+    public void onAuthenticationFailure(
+            HttpServletRequest request, HttpServletResponse response, AuthenticationException e)
+            throws IOException, ServletException {
+        response.sendRedirect(redirectUri);
+    }
+}

--- a/api/src/main/java/com/dnd/sbooky/api/security/OAuth2SuccessHandler.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/OAuth2SuccessHandler.java
@@ -21,7 +21,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
     private final TokenProvider tokenProvider;
     private final RedisRepository redisRepository;
 
-    @Value("${login.redirect-uri}")
+    @Value("${login.success.redirect-uri}")
     private String redirectUri;
 
     @Override

--- a/api/src/main/java/com/dnd/sbooky/api/security/SecurityConfig.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/SecurityConfig.java
@@ -28,6 +28,7 @@ public class SecurityConfig {
     private final TokenAuthenticationFilter tokenAuthenticationFilter;
     private final TokenExceptionFilter tokenExceptionFilter;
     private final FailedAuthenticationEntryPoint failedAuthenticationEntryPoint;
+    private final OAuth2FailureHandler oAuth2FailureHandler;
 
     private static final String[] allowUrls = {
         "/swagger-resources/**",
@@ -73,7 +74,8 @@ public class SecurityConfig {
                                 oauth
                                         .authorizationEndpoint(endPoint -> endPoint.baseUri("/api/login"))
                                         .userInfoEndpoint(c -> c.userService(oAuth2UserService))
-                                        .successHandler(oAuth2SuccessHandler))
+                                        .successHandler(oAuth2SuccessHandler)
+                                        .failureHandler(oAuth2FailureHandler))
                 .exceptionHandling(
                         exceptionHandling ->
                                 exceptionHandling.authenticationEntryPoint(failedAuthenticationEntryPoint))

--- a/api/src/main/resources/security.yml
+++ b/api/src/main/resources/security.yml
@@ -21,5 +21,7 @@ jwt:
   key: ${JWT_KEY}
 
 login:
-  redirect-uri: ${REDIRECT_URI}
+  redirect-uri:
+    success: ${REDIRECT_URI_SUCCESS}
+    failure: ${REDIRECT_URI_FAILURE}
 


### PR DESCRIPTION
## 연관된 이슈

closes #142 

## 작업 내용

로그인 실패 핸들러를 추가하였습니다.

## 리뷰 요구사항

dev 이슈로 merge 수행(협의 완료)