### PR TITLE
책 수정 요청 DTO 검증을 수정한다.

### DIFF
--- a/api/src/main/java/com/dnd/sbooky/api/book/UpdateBookUseCase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/book/UpdateBookUseCase.java
@@ -3,7 +3,6 @@ package com.dnd.sbooky.api.book;
 import com.dnd.sbooky.api.book.exception.BookForbiddenException;
 import com.dnd.sbooky.api.book.request.UpdateBookRequest;
 import com.dnd.sbooky.api.member.exception.MemberNotFoundException;
-import com.dnd.sbooky.api.point.AccumulatePointUseCase;
 import com.dnd.sbooky.api.support.error.ErrorType;
 import com.dnd.sbooky.core.book.BookEntity;
 import com.dnd.sbooky.core.book.MemberBookEntity;
@@ -19,7 +18,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class UpdateBookUseCase {
 
     private final MemberBookRepository memberBookRepository;
-    private final AccumulatePointUseCase accumulatePointUseCase;
 
     public void update(Long memberId, Long memberBookId, UpdateBookRequest request) {
 

--- a/api/src/main/java/com/dnd/sbooky/api/book/request/RegisterBookRequest.java
+++ b/api/src/main/java/com/dnd/sbooky/api/book/request/RegisterBookRequest.java
@@ -16,6 +16,7 @@ public record RegisterBookRequest(
         String title,
 
         @Schema(description = "저자")
+        @NotBlank
         String author,
 
         @Schema(description = "출판일")

--- a/api/src/main/java/com/dnd/sbooky/api/book/request/RegisterBookRequest.java
+++ b/api/src/main/java/com/dnd/sbooky/api/book/request/RegisterBookRequest.java
@@ -10,18 +10,27 @@ import org.springframework.format.annotation.DateTimeFormat;
 
 @Schema(description = "책 등록 요청 DTO")
 public record RegisterBookRequest(
-        // @formatter:off
-        @Schema(description = "책 제목") @NotBlank String title,
-        @Schema(description = "저자") String author,
-        @Schema(description = "출판일") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate publishedAt,
-        @Schema(
-                        description = "읽은 상태",
-                        allowableValues = {"WANT_TO_READ", "READING", "COMPLETED"})
-                @Enum(enumClass = ReadStatus.class)
-                String readStatus,
-        @Schema(description = "썸네일 URL")
-                @Pattern(regexp = "^$|^(http|https)://.*", message = "http 또는 https로 시작하는 URL을 입력해주세요.")
-                String thumbnailUrl) {
+        // spotless:off
+        @Schema(description = "책 제목")
+        @NotBlank
+        String title,
 
-    // @formatter:on
+        @Schema(description = "저자")
+        String author,
+
+        @Schema(description = "출판일")
+        @DateTimeFormat(pattern = "yyyy-MM-dd")
+        LocalDate publishedAt,
+
+        @Schema(description = "읽은 상태", allowableValues = {"WANT_TO_READ", "READING", "COMPLETED"})
+        @Enum(enumClass = ReadStatus.class)
+        String readStatus,
+
+        @Schema(description = "썸네일 URL")
+        @Pattern(regexp = "^$|^(http|https)://.*", message = "http 또는 https로 시작하는 URL을 입력해주세요.")
+        String thumbnailUrl
+) {
+
 }
+
+// spotless:on

--- a/api/src/main/java/com/dnd/sbooky/api/book/request/UpdateBookRequest.java
+++ b/api/src/main/java/com/dnd/sbooky/api/book/request/UpdateBookRequest.java
@@ -9,13 +9,21 @@ import org.springframework.format.annotation.DateTimeFormat;
 
 @Schema(description = "책 수정 요청 DTO")
 public record UpdateBookRequest(
-        // todo: Message, @Size 등 추후에 추가해야함 !
+        // spotless:off
+        @Schema(description = "책 제목")
+        @NotBlank
+        String title,
 
-        @Schema(description = "책 제목") @NotBlank String title,
-        @Schema(description = "저자") @NotBlank String author,
-        @Schema(description = "출판일") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate publishedAt,
-        @Schema(
-                        description = "읽은 상태",
-                        allowableValues = {"WANT_TO_READ", "READING", "COMPLETED"})
-                @Enum(enumClass = ReadStatus.class)
-                String readStatus) {}
+        @Schema(description = "저자")
+        String author,
+
+        @Schema(description = "출판일")
+        @DateTimeFormat(pattern = "yyyy-MM-dd")
+        LocalDate publishedAt,
+
+        @Schema(description = "읽은 상태", allowableValues = {"WANT_TO_READ", "READING", "COMPLETED"})
+        @Enum(enumClass = ReadStatus.class)
+        String readStatus
+) {}
+
+// spotless:on

--- a/api/src/main/java/com/dnd/sbooky/api/book/request/UpdateBookRequest.java
+++ b/api/src/main/java/com/dnd/sbooky/api/book/request/UpdateBookRequest.java
@@ -15,6 +15,7 @@ public record UpdateBookRequest(
         String title,
 
         @Schema(description = "저자")
+        @NotBlank
         String author,
 
         @Schema(description = "출판일")

--- a/api/src/main/java/com/dnd/sbooky/api/book/response/SearchBookResponse.java
+++ b/api/src/main/java/com/dnd/sbooky/api/book/response/SearchBookResponse.java
@@ -20,9 +20,8 @@ public record SearchBookResponse(
         List<Book> books = dto.documents().stream()
                               .map(document -> new Book(
                                       document.title(),
-                                      document.authors().isEmpty() ? "" : document.authors().get(0),
-                                      document.datetime() == null
-                                              ? LocalDate.EPOCH : document.datetime().toLocalDate(),
+                                      document.authors().isEmpty() ? "작자 미상" : document.authors().get(0),
+                                      document.datetime() == null ? LocalDate.EPOCH : document.datetime().toLocalDate(),
                                       document.extractThumbnailFileName())
                               ).toList();
 


### PR DESCRIPTION
## 연관된 이슈

resolves #148, fixes #143

## 작업 내용

책 수정 요청 DTO에서 `@NotBlank` 어노테이션을 제거하여 공백을 허용합니다.

## 리뷰 요구사항

현재 책 수정을 위해서 아래와 같은 정보가 필요합니다. 

- 제목
- 저자
- 출판일
- 읽은 상태

하지만 현재 책 수정이 사용되는 목적은 **'읽은 상태'** 를 수정하기 위한 목적인데 이걸 세분화하고 싶어요!

분리하기 위해서 프론트 분들에게 말씀을 드리고 같이 세분화하는게 좋을 것 같다고 판단이 들어서 일단 1차적으로 이번 PR 작업을 진행했습니다. 