### PR TITLE
처리율 제한 장치를 도입한다.

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "develop"
-      - "feat/#157-login"
 
 jobs:
   build:

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - "develop"
-      - "test/login"
+      - "feat/#157-login"
 
 jobs:
   build:

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "develop"
+      - "test/login"
 
 jobs:
   build:

--- a/api/src/main/java/com/dnd/sbooky/SbookyApplication.java
+++ b/api/src/main/java/com/dnd/sbooky/SbookyApplication.java
@@ -2,8 +2,10 @@ package com.dnd.sbooky;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class SbookyApplication {
     public static void main(String[] args) {
         SpringApplication.run(SbookyApplication.class, args);

--- a/api/src/main/java/com/dnd/sbooky/api/config/RateLimitInterceptor.java
+++ b/api/src/main/java/com/dnd/sbooky/api/config/RateLimitInterceptor.java
@@ -1,0 +1,52 @@
+package com.dnd.sbooky.api.config;
+
+import io.github.bucket4j.ConsumptionProbe;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RateLimitInterceptor implements HandlerInterceptor {
+
+    // fixme: 특정 클라이언트의 API를 과도하게 호출하는 경우에 대비할 순 없을까?
+    private static final String GLOBAL_API_KEY = "GLOBAL_API_KEY";
+
+    private final RateLimiter rateLimiter;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+            throws Exception {
+
+        ConsumptionProbe probe = rateLimiter.checkRateLimit(GLOBAL_API_KEY);
+
+        if (probe.isConsumed()) {
+            handleAllowedRequest(response, probe);
+            return true;
+        }
+
+        handleRateLimitedRequest(response, probe);
+        return false;
+    }
+
+    private void handleAllowedRequest(HttpServletResponse response, ConsumptionProbe probe) {
+        long remainingTokens = probe.getRemainingTokens();
+        response.addHeader("X-Rate-Limit-Remaining", Long.toString(remainingTokens));
+        log.info("Success to consume 1 token! Remaining tokens: {}", remainingTokens);
+    }
+
+    private void handleRateLimitedRequest(HttpServletResponse response, ConsumptionProbe probe)
+            throws IOException {
+
+        long waitTime = probe.getNanosToWaitForRefill() / 1_000_000_000;
+        response.setStatus(429);
+        response.addHeader("X-Rate-Limit-Retry-After-Seconds", Long.toString(waitTime));
+        response.getWriter().write("Rate limit exceeded. Try again in " + waitTime + " seconds.");
+        log.warn("Rate limit exceeded. Remaining tokens: {}", probe.getRemainingTokens());
+    }
+}

--- a/api/src/main/java/com/dnd/sbooky/api/config/RateLimitInterceptor.java
+++ b/api/src/main/java/com/dnd/sbooky/api/config/RateLimitInterceptor.java
@@ -1,11 +1,20 @@
 package com.dnd.sbooky.api.config;
 
+import com.dnd.sbooky.api.support.error.ErrorType;
+import com.dnd.sbooky.api.support.response.ApiResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.bucket4j.ConsumptionProbe;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
@@ -14,16 +23,23 @@ import org.springframework.web.servlet.HandlerInterceptor;
 @RequiredArgsConstructor
 public class RateLimitInterceptor implements HandlerInterceptor {
 
-    // fixme: 특정 클라이언트의 API를 과도하게 호출하는 경우에 대비할 순 없을까?
-    private static final String GLOBAL_API_KEY = "GLOBAL_API_KEY";
+    private static final String CLIENT_KEY_PREFIX = "rate-limit:";
 
     private final RateLimiter rateLimiter;
+    private final ObjectMapper objectMapper;
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
             throws Exception {
 
-        ConsumptionProbe probe = rateLimiter.checkRateLimit(GLOBAL_API_KEY);
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || authentication instanceof AnonymousAuthenticationToken) {
+            handleUnauthorized(response);
+            return false;
+        }
+
+        String clientKey = CLIENT_KEY_PREFIX + authentication.getName();
+        ConsumptionProbe probe = rateLimiter.checkRateLimit(clientKey);
 
         if (probe.isConsumed()) {
             handleAllowedRequest(response, probe);
@@ -34,19 +50,31 @@ public class RateLimitInterceptor implements HandlerInterceptor {
         return false;
     }
 
+    private void handleUnauthorized(HttpServletResponse response) throws IOException {
+
+        response.setStatus(ErrorType.AUTHENTICATION_FAILED.getStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+        objectMapper.writeValue(
+                response.getWriter(), ApiResponse.error(ErrorType.AUTHENTICATION_FAILED));
+    }
+
     private void handleAllowedRequest(HttpServletResponse response, ConsumptionProbe probe) {
         long remainingTokens = probe.getRemainingTokens();
         response.addHeader("X-Rate-Limit-Remaining", Long.toString(remainingTokens));
-        log.info("Success to consume 1 token! Remaining tokens: {}", remainingTokens);
     }
 
     private void handleRateLimitedRequest(HttpServletResponse response, ConsumptionProbe probe)
             throws IOException {
 
-        long waitTime = probe.getNanosToWaitForRefill() / 1_000_000_000;
-        response.setStatus(429);
-        response.addHeader("X-Rate-Limit-Retry-After-Seconds", Long.toString(waitTime));
-        response.getWriter().write("Rate limit exceeded. Try again in " + waitTime + " seconds.");
-        log.warn("Rate limit exceeded. Remaining tokens: {}", probe.getRemainingTokens());
+        long retryAfterSeconds = probe.getNanosToWaitForRefill() / 1_000_000_000;
+        Map<String, Long> errorData = new HashMap<>();
+        errorData.put("retryAfter", retryAfterSeconds);
+
+        response.setStatus(ErrorType.RATE_LIMIT_EXCEEDED.getStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+        objectMapper.writeValue(
+                response.getWriter(), ApiResponse.error(ErrorType.RATE_LIMIT_EXCEEDED, errorData));
     }
 }

--- a/api/src/main/java/com/dnd/sbooky/api/config/RateLimitPolicy.java
+++ b/api/src/main/java/com/dnd/sbooky/api/config/RateLimitPolicy.java
@@ -10,21 +10,22 @@ import org.springframework.stereotype.Component;
 public class RateLimitPolicy {
 
     // spotless:off
-    private static final int INTERVAL_CAPACITY = 625;
-    private static final int INTERVAL_REFILL = 625;
-    private static final int INTERVAL_DURATION_MINUTES = 30;
+
+    // todo: 해당 값을 테스트를 통해 조정할 계획입니다.
+    private static final int INTERVAL_CAPACITY = 30;
+    private static final int INTERVAL_REFILL = 5;
+    private static final int INTERVAL_DURATION_SECONDS = 20;
 
     /**
-     * 30분 제한 - 일일 제한을 48개 구간으로 나눔 (30,000 / 48 = 625)
+     * 기본 30개의 토큰을 20초마다 5개씩 그리디하게 리필하는 RateLimit 정책을 설정합니다.
      */
     public BucketConfiguration createBucketConfig() {
         return BucketConfiguration
                 .builder()
                 .addLimit(limit -> limit
                         .capacity(INTERVAL_CAPACITY)
-                        .refillIntervally(INTERVAL_REFILL, Duration.ofMinutes(INTERVAL_DURATION_MINUTES)))
+                        .refillGreedy(INTERVAL_REFILL, Duration.ofSeconds(INTERVAL_DURATION_SECONDS)))
                 .build();
     }
-
     // spotless:on
 }

--- a/api/src/main/java/com/dnd/sbooky/api/config/RateLimitPolicy.java
+++ b/api/src/main/java/com/dnd/sbooky/api/config/RateLimitPolicy.java
@@ -1,0 +1,30 @@
+package com.dnd.sbooky.api.config;
+
+import io.github.bucket4j.BucketConfiguration;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RateLimitPolicy {
+
+    // spotless:off
+    private static final int INTERVAL_CAPACITY = 625;
+    private static final int INTERVAL_REFILL = 625;
+    private static final int INTERVAL_DURATION_MINUTES = 30;
+
+    /**
+     * 30분 제한 - 일일 제한을 48개 구간으로 나눔 (30,000 / 48 = 625)
+     */
+    public BucketConfiguration createBucketConfig() {
+        return BucketConfiguration
+                .builder()
+                .addLimit(limit -> limit
+                        .capacity(INTERVAL_CAPACITY)
+                        .refillIntervally(INTERVAL_REFILL, Duration.ofMinutes(INTERVAL_DURATION_MINUTES)))
+                .build();
+    }
+
+    // spotless:on
+}

--- a/api/src/main/java/com/dnd/sbooky/api/config/RateLimiter.java
+++ b/api/src/main/java/com/dnd/sbooky/api/config/RateLimiter.java
@@ -1,0 +1,21 @@
+package com.dnd.sbooky.api.config;
+
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.ConsumptionProbe;
+import io.github.bucket4j.distributed.proxy.ProxyManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RateLimiter {
+
+    private final ProxyManager<String> proxyManager;
+    private final RateLimitPolicy rateLimitPolicy;
+
+    public ConsumptionProbe checkRateLimit(String clientKey) {
+
+        Bucket bucket = proxyManager.builder().build(clientKey, rateLimitPolicy::createBucketConfig);
+        return bucket.tryConsumeAndReturnRemaining(1);
+    }
+}

--- a/api/src/main/java/com/dnd/sbooky/api/config/WebConfig.java
+++ b/api/src/main/java/com/dnd/sbooky/api/config/WebConfig.java
@@ -1,15 +1,25 @@
 package com.dnd.sbooky.api.config;
 
 import com.dnd.sbooky.api.support.converter.ReadStatusConverter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+
+    private final RateLimitInterceptor rateLimitInterceptor;
 
     @Override
     public void addFormatters(FormatterRegistry registry) {
         registry.addConverter(new ReadStatusConverter());
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(rateLimitInterceptor).addPathPatterns("/api/books");
     }
 }

--- a/api/src/main/java/com/dnd/sbooky/api/security/CustomAuthorizationRequestResolver.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/CustomAuthorizationRequestResolver.java
@@ -1,28 +1,31 @@
 package com.dnd.sbooky.api.security;
 
-import static com.dnd.sbooky.api.security.EnvironmentConstants.CLIENT_ENVIRONMENT;
+import static com.dnd.sbooky.api.security.EnvironmentConstants.STATE_DELIMITER;
 
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.Base64;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 public class CustomAuthorizationRequestResolver implements OAuth2AuthorizationRequestResolver {
 
     private static final String AUTHORIZATION_REQUEST_BASE_URI = "/api/login";
+    private static final String STATE_PARAM = "state";
+
     private final OAuth2AuthorizationRequestResolver defaultAuthorizationRequestResolver;
-    private final RedirectProperties redirectProperties;
 
     public CustomAuthorizationRequestResolver(
-            ClientRegistrationRepository clientRegistrationRepository,
-            RedirectProperties redirectProperties) {
+            ClientRegistrationRepository clientRegistrationRepository) {
         this.defaultAuthorizationRequestResolver =
                 new DefaultOAuth2AuthorizationRequestResolver(
                         clientRegistrationRepository, AUTHORIZATION_REQUEST_BASE_URI);
-        this.redirectProperties = redirectProperties;
     }
 
     @Override
@@ -47,21 +50,14 @@ public class CustomAuthorizationRequestResolver implements OAuth2AuthorizationRe
             return null;
         }
 
-        String environment = request.getParameter(CLIENT_ENVIRONMENT);
-        String redirectUri;
+        String envParam = request.getParameter(STATE_PARAM);
+        Environment environment = Environment.fromString(envParam);
 
-        if ("local".equals(environment)) {
-            redirectUri = redirectProperties.getLocal();
-        } else if ("dev".equals(environment)) {
-            redirectUri = redirectProperties.getDev();
-        } else if ("prod".equals(environment)) {
-            redirectUri = redirectProperties.getProd();
-        } else {
-            redirectUri = redirectProperties.getLocal();
-        }
+        String stateValue = environment.getValue() + STATE_DELIMITER + UUID.randomUUID();
+        String encodedState = Base64.getEncoder().encodeToString(stateValue.getBytes());
 
-        request.getSession().setAttribute(CLIENT_ENVIRONMENT, redirectUri);
+        log.debug("Original state = {}, Encoded state = {}", stateValue, encodedState);
 
-        return authorizationRequest;
+        return OAuth2AuthorizationRequest.from(authorizationRequest).state(encodedState).build();
     }
 }

--- a/api/src/main/java/com/dnd/sbooky/api/security/CustomAuthorizationRequestResolver.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/CustomAuthorizationRequestResolver.java
@@ -16,7 +16,8 @@ public class CustomAuthorizationRequestResolver implements OAuth2AuthorizationRe
     private final OAuth2AuthorizationRequestResolver defaultAuthorizationRequestResolver;
     private final RedirectProperties redirectProperties;
 
-    public CustomAuthorizationRequestResolver(ClientRegistrationRepository clientRegistrationRepository,
+    public CustomAuthorizationRequestResolver(
+            ClientRegistrationRepository clientRegistrationRepository,
             RedirectProperties redirectProperties) {
         this.defaultAuthorizationRequestResolver =
                 new DefaultOAuth2AuthorizationRequestResolver(
@@ -32,14 +33,15 @@ public class CustomAuthorizationRequestResolver implements OAuth2AuthorizationRe
     }
 
     @Override
-    public OAuth2AuthorizationRequest resolve(HttpServletRequest request, String clientRegistrationId) {
+    public OAuth2AuthorizationRequest resolve(
+            HttpServletRequest request, String clientRegistrationId) {
         OAuth2AuthorizationRequest authorizationRequest =
                 defaultAuthorizationRequestResolver.resolve(request, clientRegistrationId);
         return customizeAuthorizationRequest(request, authorizationRequest);
     }
 
-    private OAuth2AuthorizationRequest customizeAuthorizationRequest(HttpServletRequest request,
-            OAuth2AuthorizationRequest authorizationRequest) {
+    private OAuth2AuthorizationRequest customizeAuthorizationRequest(
+            HttpServletRequest request, OAuth2AuthorizationRequest authorizationRequest) {
 
         if (authorizationRequest == null) {
             return null;
@@ -62,5 +64,4 @@ public class CustomAuthorizationRequestResolver implements OAuth2AuthorizationRe
 
         return authorizationRequest;
     }
-
 }

--- a/api/src/main/java/com/dnd/sbooky/api/security/CustomAuthorizationRequestResolver.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/CustomAuthorizationRequestResolver.java
@@ -1,0 +1,66 @@
+package com.dnd.sbooky.api.security;
+
+import static com.dnd.sbooky.api.security.TokenConstants.QUERY_PARAM;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CustomAuthorizationRequestResolver implements OAuth2AuthorizationRequestResolver {
+
+    private static final String AUTHORIZATION_REQUEST_BASE_URI = "/api/login";
+    private final OAuth2AuthorizationRequestResolver defaultAuthorizationRequestResolver;
+    private final RedirectProperties redirectProperties;
+
+    public CustomAuthorizationRequestResolver(ClientRegistrationRepository clientRegistrationRepository,
+            RedirectProperties redirectProperties) {
+        this.defaultAuthorizationRequestResolver =
+                new DefaultOAuth2AuthorizationRequestResolver(
+                        clientRegistrationRepository, AUTHORIZATION_REQUEST_BASE_URI);
+        this.redirectProperties = redirectProperties;
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request) {
+        OAuth2AuthorizationRequest authorizationRequest =
+                defaultAuthorizationRequestResolver.resolve(request);
+        return customizeAuthorizationRequest(request, authorizationRequest);
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request, String clientRegistrationId) {
+        OAuth2AuthorizationRequest authorizationRequest =
+                defaultAuthorizationRequestResolver.resolve(request, clientRegistrationId);
+        return customizeAuthorizationRequest(request, authorizationRequest);
+    }
+
+    private OAuth2AuthorizationRequest customizeAuthorizationRequest(HttpServletRequest request,
+            OAuth2AuthorizationRequest authorizationRequest) {
+
+        if (authorizationRequest == null) {
+            return null;
+        }
+
+        String environment = request.getParameter(QUERY_PARAM);
+        String redirectUri;
+
+        if ("local".equals(environment)) {
+            redirectUri = redirectProperties.getLocal();
+        } else if ("dev".equals(environment)) {
+            redirectUri = redirectProperties.getDev();
+        } else if ("prod".equals(environment)) {
+            redirectUri = redirectProperties.getProd();
+        } else {
+            redirectUri = redirectProperties.getLocal();
+        }
+
+        request.getSession().setAttribute(QUERY_PARAM, redirectUri);
+
+        return authorizationRequest;
+    }
+
+}

--- a/api/src/main/java/com/dnd/sbooky/api/security/CustomAuthorizationRequestResolver.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/CustomAuthorizationRequestResolver.java
@@ -56,8 +56,6 @@ public class CustomAuthorizationRequestResolver implements OAuth2AuthorizationRe
         String stateValue = environment.getValue() + STATE_DELIMITER + UUID.randomUUID();
         String encodedState = Base64.getEncoder().encodeToString(stateValue.getBytes());
 
-        log.debug("Original state = {}, Encoded state = {}", stateValue, encodedState);
-
         return OAuth2AuthorizationRequest.from(authorizationRequest).state(encodedState).build();
     }
 }

--- a/api/src/main/java/com/dnd/sbooky/api/security/CustomAuthorizationRequestResolver.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/CustomAuthorizationRequestResolver.java
@@ -1,6 +1,6 @@
 package com.dnd.sbooky.api.security;
 
-import static com.dnd.sbooky.api.security.TokenConstants.QUERY_PARAM;
+import static com.dnd.sbooky.api.security.EnvironmentConstants.CLIENT_ENVIRONMENT;
 
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
@@ -47,7 +47,7 @@ public class CustomAuthorizationRequestResolver implements OAuth2AuthorizationRe
             return null;
         }
 
-        String environment = request.getParameter(QUERY_PARAM);
+        String environment = request.getParameter(CLIENT_ENVIRONMENT);
         String redirectUri;
 
         if ("local".equals(environment)) {
@@ -60,7 +60,7 @@ public class CustomAuthorizationRequestResolver implements OAuth2AuthorizationRe
             redirectUri = redirectProperties.getLocal();
         }
 
-        request.getSession().setAttribute(QUERY_PARAM, redirectUri);
+        request.getSession().setAttribute(CLIENT_ENVIRONMENT, redirectUri);
 
         return authorizationRequest;
     }

--- a/api/src/main/java/com/dnd/sbooky/api/security/Environment.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/Environment.java
@@ -1,0 +1,27 @@
+package com.dnd.sbooky.api.security;
+
+import lombok.Getter;
+
+@Getter
+public enum Environment {
+    LOCAL("local"),
+    DEV("dev"),
+    PROD("prod");
+
+    private final String value;
+
+    Environment(String value) {
+        this.value = value;
+    }
+
+    public static Environment fromString(String text) {
+        for (Environment env : Environment.values()) {
+            if (env.value.equalsIgnoreCase(text)) {
+                return env;
+            }
+        }
+
+        // todo: default 환경 vs. throw Exception..
+        return LOCAL;
+    }
+}

--- a/api/src/main/java/com/dnd/sbooky/api/security/Environment.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/Environment.java
@@ -22,6 +22,6 @@ public enum Environment {
         }
 
         // todo: default 환경 vs. throw Exception..
-        return LOCAL;
+        return DEV;
     }
 }

--- a/api/src/main/java/com/dnd/sbooky/api/security/EnvironmentConstants.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/EnvironmentConstants.java
@@ -5,4 +5,6 @@ public class EnvironmentConstants {
     private EnvironmentConstants() {}
 
     public static final String CLIENT_ENVIRONMENT = "environment";
+    public static final String STATE_DELIMITER = ":";
+    public static final String CALLBACK_PATH = "/auth/callback";
 }

--- a/api/src/main/java/com/dnd/sbooky/api/security/EnvironmentConstants.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/EnvironmentConstants.java
@@ -1,0 +1,8 @@
+package com.dnd.sbooky.api.security;
+
+public class EnvironmentConstants {
+
+    private EnvironmentConstants() {}
+
+    public static final String CLIENT_ENVIRONMENT = "environment";
+}

--- a/api/src/main/java/com/dnd/sbooky/api/security/EnvironmentConstants.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/EnvironmentConstants.java
@@ -4,7 +4,5 @@ public class EnvironmentConstants {
 
     private EnvironmentConstants() {}
 
-    public static final String CLIENT_ENVIRONMENT = "environment";
     public static final String STATE_DELIMITER = ":";
-    public static final String CALLBACK_PATH = "/auth/callback";
 }

--- a/api/src/main/java/com/dnd/sbooky/api/security/LoginRedirectProperties.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/LoginRedirectProperties.java
@@ -8,9 +8,8 @@ import org.springframework.stereotype.Component;
 @Getter
 @Setter
 @Component
-@ConfigurationProperties(prefix = "redirect")
-public class RedirectProperties {
-
+@ConfigurationProperties(prefix = "login.redirect-uri")
+public class LoginRedirectProperties {
     private String local;
     private String prod;
     private String dev;

--- a/api/src/main/java/com/dnd/sbooky/api/security/LoginRedirectUrlResolver.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/LoginRedirectUrlResolver.java
@@ -55,4 +55,3 @@ public class LoginRedirectUrlResolver {
         };
     }
 }
-

--- a/api/src/main/java/com/dnd/sbooky/api/security/LoginRedirectUrlResolver.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/LoginRedirectUrlResolver.java
@@ -1,0 +1,58 @@
+package com.dnd.sbooky.api.security;
+
+import static com.dnd.sbooky.api.security.EnvironmentConstants.STATE_DELIMITER;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Base64;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LoginRedirectUrlResolver {
+
+    private static final String STATE_PARAM = "state";
+    private static final String SUCCESS_PATH = "/auth/callback";
+    private static final String FAILURE_PATH = "/login";
+
+    private final LoginRedirectProperties redirectProperties;
+
+    public String resolveRedirectUrl(HttpServletRequest request, boolean isFailure) {
+        Environment environment = resolveEnvironment(request);
+        String baseUrl = getBaseUrlForEnvironment(environment);
+
+        return isFailure ? baseUrl + FAILURE_PATH : baseUrl + SUCCESS_PATH;
+    }
+
+    private Environment resolveEnvironment(HttpServletRequest request) {
+        String state = request.getParameter(STATE_PARAM);
+        if (state == null || state.isEmpty()) {
+            throw new IllegalArgumentException("State parameter is missing!");
+        }
+
+        try {
+            String decodedState = new String(Base64.getDecoder().decode(state));
+
+            String[] stateParts = decodedState.split(STATE_DELIMITER);
+
+            if (stateParts.length != 2) {
+                throw new IllegalArgumentException("Invalid state parameter format!");
+            }
+
+            return Environment.fromString(stateParts[0]);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid state parameter encoding");
+        }
+    }
+
+    private String getBaseUrlForEnvironment(Environment environment) {
+        return switch (environment) {
+            case LOCAL -> redirectProperties.getLocal();
+            case DEV -> redirectProperties.getDev();
+            case PROD -> redirectProperties.getProd();
+        };
+    }
+}
+

--- a/api/src/main/java/com/dnd/sbooky/api/security/OAuth2FailureHandler.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/OAuth2FailureHandler.java
@@ -5,22 +5,24 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class OAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler {
 
-    @Value("${login.redirect-uri.failure}")
-    private String redirectUri;
+    private final LoginRedirectUrlResolver redirectUrlResolver;
 
     @Override
     public void onAuthenticationFailure(
             HttpServletRequest request, HttpServletResponse response, AuthenticationException e)
             throws IOException, ServletException {
-        response.sendRedirect(redirectUri);
+
+        String redirectUrl = redirectUrlResolver.resolveRedirectUrl(request, true);
+        response.sendRedirect(redirectUrl);
     }
 }

--- a/api/src/main/java/com/dnd/sbooky/api/security/OAuth2SuccessHandler.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/OAuth2SuccessHandler.java
@@ -1,6 +1,7 @@
 package com.dnd.sbooky.api.security;
 
-import static com.dnd.sbooky.api.security.EnvironmentConstants.CLIENT_ENVIRONMENT;
+import static com.dnd.sbooky.api.security.EnvironmentConstants.CALLBACK_PATH;
+import static com.dnd.sbooky.api.security.EnvironmentConstants.STATE_DELIMITER;
 import static com.dnd.sbooky.api.security.TokenConstants.REFRESH_TOKEN_EXPIRE_TIME;
 
 import com.dnd.sbooky.api.support.RedisKey;
@@ -8,18 +9,24 @@ import com.dnd.sbooky.core.RedisRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Base64;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
+    private static final String STATE_PARAM = "state";
+
     private final TokenProvider tokenProvider;
     private final RedisRepository redisRepository;
+    private final RedirectProperties redirectProperties;
 
     @Override
     public void onAuthenticationSuccess(
@@ -27,29 +34,64 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
             throws IOException {
 
         String refreshToken = tokenProvider.generateRefreshToken(authentication);
-        redisRepository.setData(getKey(authentication), refreshToken, REFRESH_TOKEN_EXPIRE_TIME);
+        String redisKey = getRedisKey(authentication);
+        redisRepository.setData(redisKey, refreshToken, REFRESH_TOKEN_EXPIRE_TIME);
 
-        String callbackUrl = getCallbackUrl(request) + "/auth/callback";
+        String baseUrl = resolveRedirectUrl(request);
+        String callbackUrl = baseUrl + CALLBACK_PATH;
+        String redirectUrl = buildRedirectUrl(callbackUrl, refreshToken);
 
-        String redirectUrl =
-                UriComponentsBuilder.fromUriString(callbackUrl)
-                        .queryParam("refreshToken", refreshToken)
-                        .build()
-                        .toUriString();
+        log.debug("Redirect URL: {}", redirectUrl);
 
         response.sendRedirect(redirectUrl);
     }
 
-    private String getKey(Authentication authentication) {
-        StringBuilder sb = new StringBuilder();
-        return sb.append(RedisKey.refreshTokenPrefix).append(authentication.getName()).toString();
+    private String getRedisKey(Authentication authentication) {
+        return RedisKey.refreshTokenPrefix + authentication.getName();
     }
 
-    private String getCallbackUrl(HttpServletRequest request) {
+    private String resolveRedirectUrl(HttpServletRequest request) {
+        String state = request.getParameter(STATE_PARAM);
+        if (state == null || state.isEmpty()) {
+            log.error("State parameter is missing");
+            throw new IllegalArgumentException("State parameter is missing!");
+        }
 
-        String callBackUrl = (String) request.getSession().getAttribute(CLIENT_ENVIRONMENT);
-        request.getSession().removeAttribute(CLIENT_ENVIRONMENT);
+        try {
+            String decodedState = new String(Base64.getDecoder().decode(state));
 
-        return callBackUrl;
+            if (log.isDebugEnabled()) {
+                log.debug("Decoded state: {}", decodedState);
+            }
+
+            String[] stateParts = decodedState.split(STATE_DELIMITER);
+
+            if (stateParts.length != 2) {
+                log.error("Invalid state format: {}", decodedState);
+                throw new IllegalArgumentException("Invalid state parameter format!");
+            }
+
+            Environment environment = Environment.fromString(stateParts[0]);
+            return getRedirectUrlForEnvironment(environment);
+
+        } catch (IllegalArgumentException e) {
+            log.error("Failed to decode state parameter: {}", state, e);
+            throw new IllegalArgumentException("Invalid state parameter encoding");
+        }
+    }
+
+    private String getRedirectUrlForEnvironment(Environment environment) {
+        return switch (environment) {
+            case LOCAL -> redirectProperties.getLocal();
+            case DEV -> redirectProperties.getDev();
+            case PROD -> redirectProperties.getProd();
+        };
+    }
+
+    private String buildRedirectUrl(String baseUrl, String refreshToken) {
+        return UriComponentsBuilder.fromUriString(baseUrl)
+                .queryParam("refreshToken", refreshToken)
+                .build()
+                .toUriString();
     }
 }

--- a/api/src/main/java/com/dnd/sbooky/api/security/OAuth2SuccessHandler.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/OAuth2SuccessHandler.java
@@ -1,7 +1,5 @@
 package com.dnd.sbooky.api.security;
 
-import static com.dnd.sbooky.api.security.EnvironmentConstants.CALLBACK_PATH;
-import static com.dnd.sbooky.api.security.EnvironmentConstants.STATE_DELIMITER;
 import static com.dnd.sbooky.api.security.TokenConstants.REFRESH_TOKEN_EXPIRE_TIME;
 
 import com.dnd.sbooky.api.support.RedisKey;
@@ -9,7 +7,6 @@ import com.dnd.sbooky.core.RedisRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.Base64;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
@@ -22,11 +19,9 @@ import org.springframework.web.util.UriComponentsBuilder;
 @RequiredArgsConstructor
 public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
-    private static final String STATE_PARAM = "state";
-
+    private final LoginRedirectUrlResolver redirectUrlResolver;
     private final TokenProvider tokenProvider;
     private final RedisRepository redisRepository;
-    private final RedirectProperties redirectProperties;
 
     @Override
     public void onAuthenticationSuccess(
@@ -37,12 +32,8 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         String redisKey = getRedisKey(authentication);
         redisRepository.setData(redisKey, refreshToken, REFRESH_TOKEN_EXPIRE_TIME);
 
-        String baseUrl = resolveRedirectUrl(request);
-        String callbackUrl = baseUrl + CALLBACK_PATH;
+        String callbackUrl = redirectUrlResolver.resolveRedirectUrl(request, false);
         String redirectUrl = buildRedirectUrl(callbackUrl, refreshToken);
-
-        log.debug("Redirect URL: {}", redirectUrl);
-
         response.sendRedirect(redirectUrl);
     }
 
@@ -50,48 +41,10 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         return RedisKey.refreshTokenPrefix + authentication.getName();
     }
 
-    private String resolveRedirectUrl(HttpServletRequest request) {
-        String state = request.getParameter(STATE_PARAM);
-        if (state == null || state.isEmpty()) {
-            log.error("State parameter is missing");
-            throw new IllegalArgumentException("State parameter is missing!");
-        }
-
-        try {
-            String decodedState = new String(Base64.getDecoder().decode(state));
-
-            if (log.isDebugEnabled()) {
-                log.debug("Decoded state: {}", decodedState);
-            }
-
-            String[] stateParts = decodedState.split(STATE_DELIMITER);
-
-            if (stateParts.length != 2) {
-                log.error("Invalid state format: {}", decodedState);
-                throw new IllegalArgumentException("Invalid state parameter format!");
-            }
-
-            Environment environment = Environment.fromString(stateParts[0]);
-            return getRedirectUrlForEnvironment(environment);
-
-        } catch (IllegalArgumentException e) {
-            log.error("Failed to decode state parameter: {}", state, e);
-            throw new IllegalArgumentException("Invalid state parameter encoding");
-        }
-    }
-
-    private String getRedirectUrlForEnvironment(Environment environment) {
-        return switch (environment) {
-            case LOCAL -> redirectProperties.getLocal();
-            case DEV -> redirectProperties.getDev();
-            case PROD -> redirectProperties.getProd();
-        };
-    }
-
     private String buildRedirectUrl(String baseUrl, String refreshToken) {
         return UriComponentsBuilder.fromUriString(baseUrl)
-                .queryParam("refreshToken", refreshToken)
-                .build()
-                .toUriString();
+                                   .queryParam("refreshToken", refreshToken)
+                                   .build()
+                                   .toUriString();
     }
 }

--- a/api/src/main/java/com/dnd/sbooky/api/security/OAuth2SuccessHandler.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/OAuth2SuccessHandler.java
@@ -1,6 +1,7 @@
 package com.dnd.sbooky.api.security;
 
-import static com.dnd.sbooky.api.security.TokenConstants.*;
+import static com.dnd.sbooky.api.security.TokenConstants.QUERY_PARAM;
+import static com.dnd.sbooky.api.security.TokenConstants.REFRESH_TOKEN_EXPIRE_TIME;
 
 import com.dnd.sbooky.api.support.RedisKey;
 import com.dnd.sbooky.core.RedisRepository;
@@ -8,21 +9,17 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
 
-@RequiredArgsConstructor
 @Component
+@RequiredArgsConstructor
 public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
     private final TokenProvider tokenProvider;
     private final RedisRepository redisRepository;
-
-    @Value("${login.redirect-uri.success}")
-    private String redirectUri;
 
     @Override
     public void onAuthenticationSuccess(
@@ -31,12 +28,15 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
         String refreshToken = tokenProvider.generateRefreshToken(authentication);
         redisRepository.setData(getKey(authentication), refreshToken, REFRESH_TOKEN_EXPIRE_TIME);
-        String redirectUri =
-                UriComponentsBuilder.fromUriString(this.redirectUri)
-                        .queryParam("refreshToken", refreshToken)
-                        .build()
-                        .toUriString();
-        response.sendRedirect(redirectUri);
+
+        String callbackUrl = getCallbackUrl(request) + "/auth/callback";
+
+        String redirectUrl = UriComponentsBuilder.fromUriString(callbackUrl)
+                                                 .queryParam("refreshToken", refreshToken)
+                                                 .build()
+                                                 .toUriString();
+
+        response.sendRedirect(redirectUrl);
     }
 
     private String getKey(Authentication authentication) {
@@ -44,16 +44,11 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         return sb.append(RedisKey.refreshTokenPrefix).append(authentication.getName()).toString();
     }
 
-    //    private void setRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
-    //        ResponseCookie cookie =
-    //                ResponseCookie.from(REFRESH_TOKEN, refreshToken)
-    //                        .secure(true)
-    //                        .sameSite(SameSite.NONE.getValue())
-    //                        .httpOnly(true)
-    //                        .maxAge(REFRESH_TOKEN_EXPIRE_TIME)
-    //                        .path("/")
-    //                        .build();
-    //        response.addHeader(SET_COOKIE, cookie.toString());
-    //    }
+    private String getCallbackUrl(HttpServletRequest request) {
 
+        String redirectUri = (String) request.getSession().getAttribute(QUERY_PARAM);
+        request.getSession().removeAttribute(QUERY_PARAM);
+
+        return redirectUri;
+    }
 }

--- a/api/src/main/java/com/dnd/sbooky/api/security/OAuth2SuccessHandler.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/OAuth2SuccessHandler.java
@@ -1,6 +1,6 @@
 package com.dnd.sbooky.api.security;
 
-import static com.dnd.sbooky.api.security.TokenConstants.QUERY_PARAM;
+import static com.dnd.sbooky.api.security.EnvironmentConstants.CLIENT_ENVIRONMENT;
 import static com.dnd.sbooky.api.security.TokenConstants.REFRESH_TOKEN_EXPIRE_TIME;
 
 import com.dnd.sbooky.api.support.RedisKey;
@@ -47,9 +47,9 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
     private String getCallbackUrl(HttpServletRequest request) {
 
-        String redirectUri = (String) request.getSession().getAttribute(QUERY_PARAM);
-        request.getSession().removeAttribute(QUERY_PARAM);
+        String callBackUrl = (String) request.getSession().getAttribute(CLIENT_ENVIRONMENT);
+        request.getSession().removeAttribute(CLIENT_ENVIRONMENT);
 
-        return redirectUri;
+        return callBackUrl;
     }
 }

--- a/api/src/main/java/com/dnd/sbooky/api/security/OAuth2SuccessHandler.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/OAuth2SuccessHandler.java
@@ -31,10 +31,11 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
         String callbackUrl = getCallbackUrl(request) + "/auth/callback";
 
-        String redirectUrl = UriComponentsBuilder.fromUriString(callbackUrl)
-                                                 .queryParam("refreshToken", refreshToken)
-                                                 .build()
-                                                 .toUriString();
+        String redirectUrl =
+                UriComponentsBuilder.fromUriString(callbackUrl)
+                        .queryParam("refreshToken", refreshToken)
+                        .build()
+                        .toUriString();
 
         response.sendRedirect(redirectUrl);
     }

--- a/api/src/main/java/com/dnd/sbooky/api/security/OAuth2SuccessHandler.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/OAuth2SuccessHandler.java
@@ -43,8 +43,8 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
     private String buildRedirectUrl(String baseUrl, String refreshToken) {
         return UriComponentsBuilder.fromUriString(baseUrl)
-                                   .queryParam("refreshToken", refreshToken)
-                                   .build()
-                                   .toUriString();
+                .queryParam("refreshToken", refreshToken)
+                .build()
+                .toUriString();
     }
 }

--- a/api/src/main/java/com/dnd/sbooky/api/security/RedirectProperties.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/RedirectProperties.java
@@ -1,0 +1,19 @@
+package com.dnd.sbooky.api.security;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "redirect")
+public class RedirectProperties {
+
+    private String local;
+    private String prod;
+    private String dev;
+
+}

--- a/api/src/main/java/com/dnd/sbooky/api/security/RedirectProperties.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/RedirectProperties.java
@@ -5,7 +5,6 @@ import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
-
 @Getter
 @Setter
 @Component
@@ -15,5 +14,4 @@ public class RedirectProperties {
     private String local;
     private String prod;
     private String dev;
-
 }

--- a/api/src/main/java/com/dnd/sbooky/api/security/SecurityConfig.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/SecurityConfig.java
@@ -73,8 +73,10 @@ public class SecurityConfig {
                 .oauth2Login(
                         oauth ->
                                 oauth
-                                        .authorizationEndpoint(endPoint -> endPoint
-                                                .authorizationRequestResolver(customAuthorizationRequestResolver))
+                                        .authorizationEndpoint(
+                                                endPoint ->
+                                                        endPoint.authorizationRequestResolver(
+                                                                customAuthorizationRequestResolver))
                                         .userInfoEndpoint(c -> c.userService(oAuth2UserService))
                                         .successHandler(oAuth2SuccessHandler)
                                         .failureHandler(oAuth2FailureHandler))

--- a/api/src/main/java/com/dnd/sbooky/api/security/SecurityConfig.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/SecurityConfig.java
@@ -29,6 +29,7 @@ public class SecurityConfig {
     private final TokenExceptionFilter tokenExceptionFilter;
     private final FailedAuthenticationEntryPoint failedAuthenticationEntryPoint;
     private final OAuth2FailureHandler oAuth2FailureHandler;
+    private final CustomAuthorizationRequestResolver customAuthorizationRequestResolver;
 
     private static final String[] allowUrls = {
         "/swagger-resources/**",
@@ -72,7 +73,8 @@ public class SecurityConfig {
                 .oauth2Login(
                         oauth ->
                                 oauth
-                                        .authorizationEndpoint(endPoint -> endPoint.baseUri("/api/login"))
+                                        .authorizationEndpoint(endPoint -> endPoint
+                                                .authorizationRequestResolver(customAuthorizationRequestResolver))
                                         .userInfoEndpoint(c -> c.userService(oAuth2UserService))
                                         .successHandler(oAuth2SuccessHandler)
                                         .failureHandler(oAuth2FailureHandler))

--- a/api/src/main/java/com/dnd/sbooky/api/security/TokenConstants.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/TokenConstants.java
@@ -1,6 +1,10 @@
 package com.dnd.sbooky.api.security;
 
 public class TokenConstants {
+
+    private TokenConstants() {
+    }
+
     public static final String TOKEN_PREFIX = "Bearer ";
     public static final String REFRESH_TOKEN = "refreshToken";
 
@@ -11,4 +15,7 @@ public class TokenConstants {
     public static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 14L; // 14 days
 
     public static final String KEY_ROLE = "role";
+
+    public static final String QUERY_PARAM = "environment";
+
 }

--- a/api/src/main/java/com/dnd/sbooky/api/security/TokenConstants.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/TokenConstants.java
@@ -14,6 +14,4 @@ public class TokenConstants {
     public static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 14L; // 14 days
 
     public static final String KEY_ROLE = "role";
-
-    public static final String QUERY_PARAM = "environment";
 }

--- a/api/src/main/java/com/dnd/sbooky/api/security/TokenConstants.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/TokenConstants.java
@@ -2,8 +2,7 @@ package com.dnd.sbooky.api.security;
 
 public class TokenConstants {
 
-    private TokenConstants() {
-    }
+    private TokenConstants() {}
 
     public static final String TOKEN_PREFIX = "Bearer ";
     public static final String REFRESH_TOKEN = "refreshToken";
@@ -17,5 +16,4 @@ public class TokenConstants {
     public static final String KEY_ROLE = "role";
 
     public static final String QUERY_PARAM = "environment";
-
 }

--- a/api/src/main/java/com/dnd/sbooky/api/support/error/ErrorCode.java
+++ b/api/src/main/java/com/dnd/sbooky/api/support/error/ErrorCode.java
@@ -32,5 +32,7 @@ public enum ErrorCode {
 
     // Evaluation Error
     EVALUATION_404_1,
-    ;
+
+    // Rate Limit Error
+    RATE_LIMIT_429;
 }

--- a/api/src/main/java/com/dnd/sbooky/api/support/error/ErrorType.java
+++ b/api/src/main/java/com/dnd/sbooky/api/support/error/ErrorType.java
@@ -4,6 +4,7 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.TOO_MANY_REQUESTS;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 import lombok.Getter;
@@ -14,19 +15,18 @@ import org.springframework.http.HttpStatus;
 public enum ErrorType {
 
     // TODO: 에러 타입 정의
+    // spotless:off
 
     // Server Error
     DEFAULT_ERROR(INTERNAL_SERVER_ERROR, ErrorCode.E500, "Internal server error.", LogLevel.ERROR),
     INVALID_PARAMETER(BAD_REQUEST, ErrorCode.E400_1, "Request parameter is invalid.", LogLevel.INFO),
-    REQUEST_VALIDATION_FAILED(
-            BAD_REQUEST, ErrorCode.E400_2, "Request body is invalid", LogLevel.INFO),
+    REQUEST_VALIDATION_FAILED(BAD_REQUEST, ErrorCode.E400_2, "Request body is invalid", LogLevel.INFO),
 
     // Security Error
     INVALID_TOKEN(UNAUTHORIZED, ErrorCode.SECURITY_401_1, "Invalid token.", LogLevel.INFO),
     INVALID_SIGNATURE(UNAUTHORIZED, ErrorCode.SECURITY_401_2, "Invalid signature", LogLevel.INFO),
     EXPIRED_TOKEN(UNAUTHORIZED, ErrorCode.SECURITY_401_3, "Expired accessToken", LogLevel.INFO),
-    AUTHENTICATION_FAILED(
-            UNAUTHORIZED, ErrorCode.SECURITY_401_4, "Authentication failed.", LogLevel.INFO),
+    AUTHENTICATION_FAILED(UNAUTHORIZED, ErrorCode.SECURITY_401_4, "Authentication failed.", LogLevel.INFO),
     NOT_FOUND_TOKEN(NOT_FOUND, ErrorCode.SECURITY_404_1, "Not found token", LogLevel.INFO),
 
     // Member Error
@@ -35,17 +35,19 @@ public enum ErrorType {
     // Book Error
     BOOK_ACCESS_FORBIDDEN(FORBIDDEN, ErrorCode.BOOK_403, "Book access is forbidden.", LogLevel.INFO),
     BOOK_NOT_FOUND(NOT_FOUND, ErrorCode.BOOK_404, "Book was not found.", LogLevel.INFO),
-    BOOK_READ_STATUS_NOT_COMPLETED(
-            BAD_REQUEST, ErrorCode.BOOK_400_1, "Book read status is not completed.", LogLevel.INFO),
+    BOOK_READ_STATUS_NOT_COMPLETED(BAD_REQUEST, ErrorCode.BOOK_400_1, "Book read status is not completed.", LogLevel.INFO),
 
     // Item Error
     ITEM_NOT_FOUND(NOT_FOUND, ErrorCode.ITEM_404, "Item was not found.", LogLevel.INFO),
     MEMBER_HAS_NOT_ITEM(NOT_FOUND, ErrorCode.ITEM_404_2, "Member has not item.", LogLevel.INFO),
 
     // Evaluation Error
-    EVALUATION_KEYWORD_NOT_FOUND(
-            NOT_FOUND, ErrorCode.EVALUATION_404_1, "Evaluation keyword not found.", LogLevel.INFO),
-    ;
+    EVALUATION_KEYWORD_NOT_FOUND(NOT_FOUND, ErrorCode.EVALUATION_404_1, "Evaluation keyword not found.", LogLevel.INFO),
+
+    // Rate Limit Error
+    RATE_LIMIT_EXCEEDED(TOO_MANY_REQUESTS, ErrorCode.RATE_LIMIT_429, "Rate limit exceeded. Please try again later.", LogLevel.DEBUG);
+
+    // spotless:on
 
     private final HttpStatus status;
     private final ErrorCode code;

--- a/api/src/main/resources/security.yml
+++ b/api/src/main/resources/security.yml
@@ -26,6 +26,6 @@ login:
     failure: ${REDIRECT_URI_FAILURE}
 
 redirect:
-  local: http://localhost:3000
-  prod: https://sbooky.net
-  dev: https://sbooky.net
+  local: ${REDIRECT_URI_LOCAL}
+  dev: ${REDIRECT_URI_DEV}
+  prod: ${REDIRECT_URI_PROD}

--- a/api/src/main/resources/security.yml
+++ b/api/src/main/resources/security.yml
@@ -22,10 +22,6 @@ jwt:
 
 login:
   redirect-uri:
-    success: ${REDIRECT_URI_SUCCESS}
-    failure: ${REDIRECT_URI_FAILURE}
-
-redirect:
-  local: ${REDIRECT_URI_LOCAL}
-  dev: ${REDIRECT_URI_DEV}
-  prod: ${REDIRECT_URI_PROD}
+    local: ${REDIRECT_URI_LOCAL}
+    dev: ${REDIRECT_URI_DEV}
+    prod: ${REDIRECT_URI_PROD}

--- a/api/src/main/resources/security.yml
+++ b/api/src/main/resources/security.yml
@@ -25,3 +25,7 @@ login:
     success: ${REDIRECT_URI_SUCCESS}
     failure: ${REDIRECT_URI_FAILURE}
 
+redirect:
+  local: http://localhost:3000
+  prod: https://sbooky.net
+  dev: https://sbooky.net

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -7,4 +7,8 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:5.1.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    // bucket4j (api 모듈까지 전파하기 위해 api로 설정)
+    api 'com.bucket4j:bucket4j_jdk17-core:8.14.0'
+    api 'com.bucket4j:bucket4j_jdk17-lettuce:8.14.0'
 }

--- a/core/src/main/java/com/dnd/sbooky/core/config/RateLimitRedisConfig.java
+++ b/core/src/main/java/com/dnd/sbooky/core/config/RateLimitRedisConfig.java
@@ -1,0 +1,60 @@
+package com.dnd.sbooky.core.config;
+
+import io.github.bucket4j.distributed.ExpirationAfterWriteStrategy;
+import io.github.bucket4j.distributed.proxy.ProxyManager;
+import io.github.bucket4j.redis.lettuce.Bucket4jLettuce;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisURI;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.codec.ByteArrayCodec;
+import io.lettuce.core.codec.RedisCodec;
+import io.lettuce.core.codec.StringCodec;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class RateLimitRedisConfig {
+
+    private final RedisProperties redisProperties;
+
+    @Bean
+    public RedisClient redisClient() {
+        return RedisClient.create(
+                RedisURI.builder()
+                        .withHost(redisProperties.getHost())
+                        .withPort(redisProperties.getPort())
+                        .withPassword(redisProperties.getPassword().toCharArray())
+                        .build());
+    }
+
+    /**
+     * Redis를 사용하여 분산 환경에서 동작하는 Bucket4j의 ProxyManager를 생성합니다.
+     *
+     * @param redisClient Redis 연결을 위한 클라이언트 객체
+     * @return Redis 기반의 ProxyManager 인스턴스
+     * <p>
+     * 이 메서드는 다음과 같은 작업을 수행합니다:
+     * <ol>
+     *     <li>Redis 클라이언트를 사용하여 Redis 연결을 생성합니다.</li>
+     *     <li>연결에 UTF-8 문자열 키와 바이트 배열 값을 사용하는 RedisCodec을 적용합니다.</li>
+     *     <li>Bucket4jLettuce를 사용하여 CAS(Compare-And-Swap) 기반의 ProxyManager 빌더를 생성합니다.</li>
+     *     <li>만료 전략을 설정합니다. 버킷이 최대 용량까지 리필되는 데 필요한 시간에 10초를 더한 시간 후에 만료되도록 합니다.</li>
+     *     <li>설정된 옵션으로 ProxyManager를 빌드하여 반환합니다.</li>
+     * </ol>
+     */
+    @Bean
+    public ProxyManager<String> lettuceBasedProxyManager(RedisClient redisClient) {
+
+        StatefulRedisConnection<String, byte[]> redisConnection =
+                redisClient.connect(RedisCodec.of(StringCodec.UTF8, ByteArrayCodec.INSTANCE));
+
+        return Bucket4jLettuce.casBasedBuilder(redisConnection)
+                              .expirationAfterWrite(
+                                      ExpirationAfterWriteStrategy.basedOnTimeForRefillingBucketUpToMax(
+                                              Duration.ofSeconds(10)))
+                              .build();
+    }
+}

--- a/core/src/main/java/com/dnd/sbooky/core/config/RateLimitRedisConfig.java
+++ b/core/src/main/java/com/dnd/sbooky/core/config/RateLimitRedisConfig.java
@@ -18,6 +18,9 @@ import org.springframework.context.annotation.Configuration;
 @RequiredArgsConstructor
 public class RateLimitRedisConfig {
 
+    // todo: 해당 값은 테스트를 통해 조정할 계획입니다.
+    private static final int EXPIRE_MINUTES = 1;
+
     private final RedisProperties redisProperties;
 
     @Bean
@@ -54,7 +57,7 @@ public class RateLimitRedisConfig {
         return Bucket4jLettuce.casBasedBuilder(redisConnection)
                 .expirationAfterWrite(
                         ExpirationAfterWriteStrategy.basedOnTimeForRefillingBucketUpToMax(
-                                Duration.ofSeconds(10)))
+                                Duration.ofMinutes(EXPIRE_MINUTES)))
                 .build();
     }
 }

--- a/core/src/main/java/com/dnd/sbooky/core/config/RateLimitRedisConfig.java
+++ b/core/src/main/java/com/dnd/sbooky/core/config/RateLimitRedisConfig.java
@@ -52,9 +52,9 @@ public class RateLimitRedisConfig {
                 redisClient.connect(RedisCodec.of(StringCodec.UTF8, ByteArrayCodec.INSTANCE));
 
         return Bucket4jLettuce.casBasedBuilder(redisConnection)
-                              .expirationAfterWrite(
-                                      ExpirationAfterWriteStrategy.basedOnTimeForRefillingBucketUpToMax(
-                                              Duration.ofSeconds(10)))
-                              .build();
+                .expirationAfterWrite(
+                        ExpirationAfterWriteStrategy.basedOnTimeForRefillingBucketUpToMax(
+                                Duration.ofSeconds(10)))
+                .build();
     }
 }

--- a/core/src/main/java/com/dnd/sbooky/core/config/RedisConfig.java
+++ b/core/src/main/java/com/dnd/sbooky/core/config/RedisConfig.java
@@ -1,6 +1,6 @@
 package com.dnd.sbooky.core.config;
 
-import org.springframework.beans.factory.annotation.Value;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
@@ -9,26 +9,18 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
+@RequiredArgsConstructor
 public class RedisConfig {
 
-    @Value("${spring.redis.host}")
-    private String host;
-
-    @Value("${spring.redis.port}")
-    private int port;
-
-    @Value("${spring.redis.password}")
-    private String password;
+    private final RedisProperties redisProperties;
 
     @Bean
     public LettuceConnectionFactory redisConnectionFactory() {
         RedisStandaloneConfiguration redisConfiguration = new RedisStandaloneConfiguration();
-        redisConfiguration.setHostName(host);
-        redisConfiguration.setPort(port);
-        redisConfiguration.setPassword(password);
-        LettuceConnectionFactory lettuceConnectionFactory =
-                new LettuceConnectionFactory(redisConfiguration);
-        return lettuceConnectionFactory;
+        redisConfiguration.setHostName(redisProperties.getHost());
+        redisConfiguration.setPort(redisProperties.getPort());
+        redisConfiguration.setPassword(redisProperties.getPassword());
+        return new LettuceConnectionFactory(redisConfiguration);
     }
 
     @Bean

--- a/core/src/main/java/com/dnd/sbooky/core/config/RedisProperties.java
+++ b/core/src/main/java/com/dnd/sbooky/core/config/RedisProperties.java
@@ -1,0 +1,20 @@
+package com.dnd.sbooky.core.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Redis Properties Class.
+ *
+ * @author Seungjo, Jeong
+ */
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "spring.redis")
+public class RedisProperties {
+
+    private String host;
+    private int port;
+    private String password;
+}


### PR DESCRIPTION
## 연관된 이슈

resolves #160 

## 작업 내용

카카오 책 검색 API (`/api/books`) 에 대해서 처리율 제한 장치를 설정했습니다.

- Bucket4j + Redis(Lettuce)
- 토큰 버킷 알고리즘 적용
- 사용자별 제한 (JWT) 기반으로 개별 버킷 할당 

## 리뷰 요구사항

> 먼저 #158 PR을 봐주세요. 해당 작업에 이어서 진행되어있습니다!

아래의 내용을 같이 정하면 좋을 것 같아요 

- ProxyManager 만료 전략 설정: 너무 짧은 경우 소멸되었다가 생성되는 과정이 너무 많아진다. 
- Rate Limit 정책 설정: 사용자 경험에 큰 영향이 없을 정도의 적절한 시간 설정이 중요할 것으로 보인다.

--- 

해당 내용으로 [블로그](https://f1v3.gitbook.io/f1v3-log/develop/external-api/rate-limiter)에 정리를 했는데 잘 이해가 안되시면 디스코드 이야기 해봐요~
