### PR TITLE
좋아요 수를 조회하는 API에 사용되는 변수명을 수정한다. 

### DIFF
--- a/api/src/main/java/com/dnd/sbooky/api/like/GetLikesController.java
+++ b/api/src/main/java/com/dnd/sbooky/api/like/GetLikesController.java
@@ -16,8 +16,8 @@ public class GetLikesController implements GetLikesApiSpec {
 
     private final GetLikesUsecase getLikesUsecase;
 
-    @GetMapping("/likes/{memberId}")
-    public ApiResponse<GetLikesResponse> getLikes(@PathVariable Long memberId) {
-        return ApiResponse.success(GetLikesResponse.from(getLikesUsecase.get(memberId)));
+    @GetMapping("/likes/{ownerId}")
+    public ApiResponse<GetLikesResponse> getLikes(@PathVariable Long ownerId) {
+        return ApiResponse.success(GetLikesResponse.from(getLikesUsecase.get(ownerId)));
     }
 }

--- a/api/src/main/java/com/dnd/sbooky/api/like/GetLikesUsecase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/like/GetLikesUsecase.java
@@ -15,9 +15,9 @@ public class GetLikesUsecase {
     private final MemberRepository memberRepository;
 
     @Transactional(readOnly = true)
-    public Long get(Long memberId) {
-        validateMember(memberId);
-        return likeRepository.countByMemberEntityId(memberId);
+    public Long get(Long ownerId) {
+        validateMember(ownerId);
+        return likeRepository.countByMemberEntityId(ownerId);
     }
 
     private void validateMember(Long memberId) {


### PR DESCRIPTION
## 연관된 이슈

closes #162 

## 작업 내용

좋아요 수 조회 시 '주인'과 '방문자'를 명확히 구분하기 위해, memberId를 ownerId로 수정

## 리뷰 요구사항

간단한 변경사항입니다.