### PR TITLE
장착한 유령 조회 API를 수정한다.

### DIFF
--- a/api/src/main/java/com/dnd/sbooky/SbookyApplication.java
+++ b/api/src/main/java/com/dnd/sbooky/SbookyApplication.java
@@ -2,8 +2,10 @@ package com.dnd.sbooky;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class SbookyApplication {
     public static void main(String[] args) {
         SpringApplication.run(SbookyApplication.class, args);

--- a/api/src/main/java/com/dnd/sbooky/api/docs/spec/DrawItemApiSpec.java
+++ b/api/src/main/java/com/dnd/sbooky/api/docs/spec/DrawItemApiSpec.java
@@ -1,6 +1,6 @@
 package com.dnd.sbooky.api.docs.spec;
 
-import com.dnd.sbooky.api.item.response.DrawItemResponse;
+import com.dnd.sbooky.api.item.v1.response.DrawItemResponse;
 import com.dnd.sbooky.api.support.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;

--- a/api/src/main/java/com/dnd/sbooky/api/docs/spec/FindItemsApiSpec.java
+++ b/api/src/main/java/com/dnd/sbooky/api/docs/spec/FindItemsApiSpec.java
@@ -1,7 +1,7 @@
 package com.dnd.sbooky.api.docs.spec;
 
-import com.dnd.sbooky.api.item.response.FindItemsResponse;
-import com.dnd.sbooky.api.item.response.FindMemberEquippedItemsResponse;
+import com.dnd.sbooky.api.item.v1.response.FindItemsResponse;
+import com.dnd.sbooky.api.item.v1.response.FindMemberEquippedItemsResponse;
 import com.dnd.sbooky.api.support.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;

--- a/api/src/main/java/com/dnd/sbooky/api/docs/spec/FindItemsV2ApiSpec.java
+++ b/api/src/main/java/com/dnd/sbooky/api/docs/spec/FindItemsV2ApiSpec.java
@@ -1,6 +1,6 @@
 package com.dnd.sbooky.api.docs.spec;
 
-import com.dnd.sbooky.api.item.v1.response.FindMemberEquippedItemsResponse;
+import com.dnd.sbooky.api.item.v2.response.FindMemberEquippedItemsResponseV2;
 import com.dnd.sbooky.api.support.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -8,5 +8,5 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @Tag(name = "[Item API v2]", description = "아이템 관련된 API v2")
 public interface FindItemsV2ApiSpec {
     @Operation(summary = "내가 장착한 아이템 조회", description = "내가 장착한 아이템 정보를 조회한다.")
-    ApiResponse<FindMemberEquippedItemsResponse> findEquippedItems(Long ownerId);
+    ApiResponse<FindMemberEquippedItemsResponseV2> findEquippedItems(Long ownerId);
 }

--- a/api/src/main/java/com/dnd/sbooky/api/docs/spec/FindItemsV2ApiSpec.java
+++ b/api/src/main/java/com/dnd/sbooky/api/docs/spec/FindItemsV2ApiSpec.java
@@ -1,0 +1,12 @@
+package com.dnd.sbooky.api.docs.spec;
+
+import com.dnd.sbooky.api.item.v1.response.FindMemberEquippedItemsResponse;
+import com.dnd.sbooky.api.support.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "[Item API v2]", description = "아이템 관련된 API v2")
+public interface FindItemsV2ApiSpec {
+    @Operation(summary = "내가 장착한 아이템 조회", description = "내가 장착한 아이템 정보를 조회한다.")
+    ApiResponse<FindMemberEquippedItemsResponse> findEquippedItems(Long ownerId);
+}

--- a/api/src/main/java/com/dnd/sbooky/api/docs/spec/SwitchEquippedItemApiSpec.java
+++ b/api/src/main/java/com/dnd/sbooky/api/docs/spec/SwitchEquippedItemApiSpec.java
@@ -1,6 +1,6 @@
 package com.dnd.sbooky.api.docs.spec;
 
-import com.dnd.sbooky.api.item.request.SwitchEquippedItemRequest;
+import com.dnd.sbooky.api.item.v1.request.SwitchEquippedItemRequest;
 import com.dnd.sbooky.api.support.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;

--- a/api/src/main/java/com/dnd/sbooky/api/item/v1/DrawItemController.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/v1/DrawItemController.java
@@ -1,7 +1,7 @@
-package com.dnd.sbooky.api.item;
+package com.dnd.sbooky.api.item.v1;
 
 import com.dnd.sbooky.api.docs.spec.DrawItemApiSpec;
-import com.dnd.sbooky.api.item.response.DrawItemResponse;
+import com.dnd.sbooky.api.item.v1.response.DrawItemResponse;
 import com.dnd.sbooky.api.support.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;

--- a/api/src/main/java/com/dnd/sbooky/api/item/v1/DrawItemUsecase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/v1/DrawItemUsecase.java
@@ -1,9 +1,9 @@
-package com.dnd.sbooky.api.item;
+package com.dnd.sbooky.api.item.v1;
 
 import static com.dnd.sbooky.api.support.error.ErrorType.*;
 
-import com.dnd.sbooky.api.item.exception.ItemNotFoundException;
-import com.dnd.sbooky.api.item.response.DrawItemResponse;
+import com.dnd.sbooky.api.item.v1.exception.ItemNotFoundException;
+import com.dnd.sbooky.api.item.v1.response.DrawItemResponse;
 import com.dnd.sbooky.api.member.exception.MemberNotFoundException;
 import com.dnd.sbooky.api.point.AccumulatePointUseCase;
 import com.dnd.sbooky.core.item.ItemCode;

--- a/api/src/main/java/com/dnd/sbooky/api/item/v1/FindEquippedItemUsecase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/v1/FindEquippedItemUsecase.java
@@ -1,6 +1,6 @@
-package com.dnd.sbooky.api.item;
+package com.dnd.sbooky.api.item.v1;
 
-import com.dnd.sbooky.api.item.response.FindEquippedItemsResponse;
+import com.dnd.sbooky.api.item.v1.response.FindEquippedItemsResponse;
 import com.dnd.sbooky.core.item.ItemCode;
 import com.dnd.sbooky.core.item.ItemType;
 import com.dnd.sbooky.core.item.MemberItemRepository;

--- a/api/src/main/java/com/dnd/sbooky/api/item/v1/FindItemsController.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/v1/FindItemsController.java
@@ -1,9 +1,9 @@
-package com.dnd.sbooky.api.item;
+package com.dnd.sbooky.api.item.v1;
 
 import com.dnd.sbooky.api.docs.spec.FindItemsApiSpec;
-import com.dnd.sbooky.api.item.response.FindEquippedItemsResponse;
-import com.dnd.sbooky.api.item.response.FindItemsResponse;
-import com.dnd.sbooky.api.item.response.FindMemberEquippedItemsResponse;
+import com.dnd.sbooky.api.item.v1.response.FindEquippedItemsResponse;
+import com.dnd.sbooky.api.item.v1.response.FindItemsResponse;
+import com.dnd.sbooky.api.item.v1.response.FindMemberEquippedItemsResponse;
 import com.dnd.sbooky.api.member.FindNicknameUsecase;
 import com.dnd.sbooky.api.support.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Parameter;

--- a/api/src/main/java/com/dnd/sbooky/api/item/v1/FindItemsUseCase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/v1/FindItemsUseCase.java
@@ -1,7 +1,7 @@
-package com.dnd.sbooky.api.item;
+package com.dnd.sbooky.api.item.v1;
 
-import com.dnd.sbooky.api.item.response.FindItemResponse;
-import com.dnd.sbooky.api.item.response.FindItemsResponse;
+import com.dnd.sbooky.api.item.v1.response.FindItemResponse;
+import com.dnd.sbooky.api.item.v1.response.FindItemsResponse;
 import com.dnd.sbooky.core.item.ItemCode;
 import com.dnd.sbooky.core.item.ItemType;
 import com.dnd.sbooky.core.item.MemberItemRepository;

--- a/api/src/main/java/com/dnd/sbooky/api/item/v1/ObtainItemUseCase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/v1/ObtainItemUseCase.java
@@ -1,8 +1,8 @@
-package com.dnd.sbooky.api.item;
+package com.dnd.sbooky.api.item.v1;
 
 import static com.dnd.sbooky.api.support.error.ErrorType.*;
 
-import com.dnd.sbooky.api.item.exception.ItemNotFoundException;
+import com.dnd.sbooky.api.item.v1.exception.ItemNotFoundException;
 import com.dnd.sbooky.api.member.exception.MemberNotFoundException;
 import com.dnd.sbooky.core.item.ItemEntity;
 import com.dnd.sbooky.core.item.ItemRepository;

--- a/api/src/main/java/com/dnd/sbooky/api/item/v1/SwitchEquippedItemController.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/v1/SwitchEquippedItemController.java
@@ -1,7 +1,7 @@
-package com.dnd.sbooky.api.item;
+package com.dnd.sbooky.api.item.v1;
 
 import com.dnd.sbooky.api.docs.spec.SwitchEquippedItemApiSpec;
-import com.dnd.sbooky.api.item.request.SwitchEquippedItemRequest;
+import com.dnd.sbooky.api.item.v1.request.SwitchEquippedItemRequest;
 import com.dnd.sbooky.api.support.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;

--- a/api/src/main/java/com/dnd/sbooky/api/item/v1/SwitchEquippedItemUsecase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/v1/SwitchEquippedItemUsecase.java
@@ -1,8 +1,8 @@
-package com.dnd.sbooky.api.item;
+package com.dnd.sbooky.api.item.v1;
 
 import static com.dnd.sbooky.api.support.error.ErrorType.*;
 
-import com.dnd.sbooky.api.item.exception.MemberHasNotItemException;
+import com.dnd.sbooky.api.item.v1.exception.MemberHasNotItemException;
 import com.dnd.sbooky.core.item.ItemCode;
 import com.dnd.sbooky.core.item.MemberItemEntity;
 import com.dnd.sbooky.core.item.MemberItemRepository;

--- a/api/src/main/java/com/dnd/sbooky/api/item/v1/exception/ItemNotFoundException.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/v1/exception/ItemNotFoundException.java
@@ -1,4 +1,4 @@
-package com.dnd.sbooky.api.item.exception;
+package com.dnd.sbooky.api.item.v1.exception;
 
 import com.dnd.sbooky.api.support.error.ApiException;
 import com.dnd.sbooky.api.support.error.ErrorType;

--- a/api/src/main/java/com/dnd/sbooky/api/item/v1/exception/MemberHasNotItemException.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/v1/exception/MemberHasNotItemException.java
@@ -1,4 +1,4 @@
-package com.dnd.sbooky.api.item.exception;
+package com.dnd.sbooky.api.item.v1.exception;
 
 import com.dnd.sbooky.api.support.error.ApiException;
 import com.dnd.sbooky.api.support.error.ErrorType;

--- a/api/src/main/java/com/dnd/sbooky/api/item/v1/request/SwitchEquippedItemRequest.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/v1/request/SwitchEquippedItemRequest.java
@@ -1,4 +1,4 @@
-package com.dnd.sbooky.api.item.request;
+package com.dnd.sbooky.api.item.v1.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;

--- a/api/src/main/java/com/dnd/sbooky/api/item/v1/response/DrawItemResponse.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/v1/response/DrawItemResponse.java
@@ -1,4 +1,4 @@
-package com.dnd.sbooky.api.item.response;
+package com.dnd.sbooky.api.item.v1.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/api/src/main/java/com/dnd/sbooky/api/item/v1/response/FindEquippedItemsResponse.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/v1/response/FindEquippedItemsResponse.java
@@ -1,4 +1,4 @@
-package com.dnd.sbooky.api.item.response;
+package com.dnd.sbooky.api.item.v1.response;
 
 import com.dnd.sbooky.core.item.ItemType;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/api/src/main/java/com/dnd/sbooky/api/item/v1/response/FindItemResponse.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/v1/response/FindItemResponse.java
@@ -1,4 +1,4 @@
-package com.dnd.sbooky.api.item.response;
+package com.dnd.sbooky.api.item.v1.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/api/src/main/java/com/dnd/sbooky/api/item/v1/response/FindItemsResponse.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/v1/response/FindItemsResponse.java
@@ -1,4 +1,4 @@
-package com.dnd.sbooky.api.item.response;
+package com.dnd.sbooky.api.item.v1.response;
 
 import com.dnd.sbooky.core.item.ItemType;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/api/src/main/java/com/dnd/sbooky/api/item/v1/response/FindMemberEquippedItemsResponse.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/v1/response/FindMemberEquippedItemsResponse.java
@@ -1,4 +1,4 @@
-package com.dnd.sbooky.api.item.response;
+package com.dnd.sbooky.api.item.v1.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/api/src/main/java/com/dnd/sbooky/api/item/v2/FindItemsControllerV2.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/v2/FindItemsControllerV2.java
@@ -3,7 +3,7 @@ package com.dnd.sbooky.api.item.v2;
 import com.dnd.sbooky.api.docs.spec.FindItemsV2ApiSpec;
 import com.dnd.sbooky.api.item.v1.FindEquippedItemUsecase;
 import com.dnd.sbooky.api.item.v1.response.FindEquippedItemsResponse;
-import com.dnd.sbooky.api.item.v1.response.FindMemberEquippedItemsResponse;
+import com.dnd.sbooky.api.item.v2.response.FindMemberEquippedItemsResponseV2;
 import com.dnd.sbooky.api.member.FindNicknameUsecase;
 import com.dnd.sbooky.api.support.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -21,10 +21,10 @@ public class FindItemsControllerV2 implements FindItemsV2ApiSpec {
     private final FindNicknameUsecase findNicknameUsecase;
 
     @GetMapping("/members/{ownerId}/items/equipped")
-    public ApiResponse<FindMemberEquippedItemsResponse> findEquippedItems(
+    public ApiResponse<FindMemberEquippedItemsResponseV2> findEquippedItems(
             @PathVariable Long ownerId) {
         FindEquippedItemsResponse equippedItemsDTO = findEquippedItemUsecase.findEquippedItems(ownerId);
         String nickname = findNicknameUsecase.findNickname(ownerId);
-        return ApiResponse.success(FindMemberEquippedItemsResponse.from(equippedItemsDTO, nickname));
+        return ApiResponse.success(FindMemberEquippedItemsResponseV2.from(equippedItemsDTO, nickname));
     }
 }

--- a/api/src/main/java/com/dnd/sbooky/api/item/v2/FindItemsControllerV2.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/v2/FindItemsControllerV2.java
@@ -1,0 +1,30 @@
+package com.dnd.sbooky.api.item.v2;
+
+import com.dnd.sbooky.api.docs.spec.FindItemsV2ApiSpec;
+import com.dnd.sbooky.api.item.v1.FindEquippedItemUsecase;
+import com.dnd.sbooky.api.item.v1.response.FindEquippedItemsResponse;
+import com.dnd.sbooky.api.item.v1.response.FindMemberEquippedItemsResponse;
+import com.dnd.sbooky.api.member.FindNicknameUsecase;
+import com.dnd.sbooky.api.support.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class FindItemsControllerV2 implements FindItemsV2ApiSpec {
+
+    private final FindEquippedItemUsecase findEquippedItemUsecase;
+    private final FindNicknameUsecase findNicknameUsecase;
+
+    @GetMapping("/members/{ownerId}/items/equipped")
+    public ApiResponse<FindMemberEquippedItemsResponse> findEquippedItems(
+            @PathVariable Long ownerId) {
+        FindEquippedItemsResponse equippedItemsDTO = findEquippedItemUsecase.findEquippedItems(ownerId);
+        String nickname = findNicknameUsecase.findNickname(ownerId);
+        return ApiResponse.success(FindMemberEquippedItemsResponse.from(equippedItemsDTO, nickname));
+    }
+}

--- a/api/src/main/java/com/dnd/sbooky/api/item/v2/FindItemsControllerV2.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/v2/FindItemsControllerV2.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api")
+@RequestMapping("/api/v2")
 @RequiredArgsConstructor
 public class FindItemsControllerV2 implements FindItemsV2ApiSpec {
 

--- a/api/src/main/java/com/dnd/sbooky/api/item/v2/response/FindMemberEquippedItemsResponseV2.java
+++ b/api/src/main/java/com/dnd/sbooky/api/item/v2/response/FindMemberEquippedItemsResponseV2.java
@@ -1,0 +1,15 @@
+package com.dnd.sbooky.api.item.v2.response;
+
+import com.dnd.sbooky.api.item.v1.response.FindEquippedItemsResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "내가 장착한 아이템 조회 응답")
+public record FindMemberEquippedItemsResponseV2(
+        @Schema(description = "아이템 타입에 따른 아이템 식별자 DTO")
+                FindEquippedItemsResponse findEquippedItemsResponse,
+        @Schema(description = "닉네임") String nickName) {
+    public static FindMemberEquippedItemsResponseV2 from(
+            FindEquippedItemsResponse findEquippedItemsResponse, String nickName) {
+        return new FindMemberEquippedItemsResponseV2(findEquippedItemsResponse, nickName);
+    }
+}

--- a/api/src/main/java/com/dnd/sbooky/api/member/PerformOnboardingUseCase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/member/PerformOnboardingUseCase.java
@@ -2,8 +2,8 @@ package com.dnd.sbooky.api.member;
 
 import static com.dnd.sbooky.api.support.error.ErrorType.MEMBER_NOT_FOUND;
 
-import com.dnd.sbooky.api.item.ObtainItemUseCase;
-import com.dnd.sbooky.api.item.SwitchEquippedItemUsecase;
+import com.dnd.sbooky.api.item.v1.ObtainItemUseCase;
+import com.dnd.sbooky.api.item.v1.SwitchEquippedItemUsecase;
 import com.dnd.sbooky.api.member.exception.MemberNotFoundException;
 import com.dnd.sbooky.api.member.request.PerformOnboardingRequest;
 import com.dnd.sbooky.core.item.ItemCode;

--- a/api/src/main/java/com/dnd/sbooky/api/security/CustomOAuth2UserService.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/CustomOAuth2UserService.java
@@ -2,7 +2,7 @@ package com.dnd.sbooky.api.security;
 
 import static com.dnd.sbooky.api.support.error.ErrorType.ITEM_NOT_FOUND;
 
-import com.dnd.sbooky.api.item.exception.ItemNotFoundException;
+import com.dnd.sbooky.api.item.v1.exception.ItemNotFoundException;
 import com.dnd.sbooky.core.item.ItemEntity;
 import com.dnd.sbooky.core.item.ItemRepository;
 import com.dnd.sbooky.core.item.MemberItemEntity;


### PR DESCRIPTION
## 연관된 이슈

closes #156 

## 작업 내용

장착한 유령 조회 API v2는 착한 유령 조회 API는 주인뿐만 아니라 방문자도 사용할 수 있도록 하였습니다.
방문자와 주인 모두 장착한 유령을 조회할 수 있기 때문에 별다른 토큰 인증 없이 ownerId를 path parameter로 전달 받아 주인을 식별하도록 하였습니다.

## 리뷰 요구사항

