### PR TITLE
디스코드를 연동하여 서버 에러를 파악한다.

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -23,4 +23,6 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
+    implementation 'com.github.napstr:logback-discord-appender:1.0.0'
 }

--- a/api/src/main/resources/logback-spring.xml
+++ b/api/src/main/resources/logback-spring.xml
@@ -1,7 +1,7 @@
 <configuration>
   <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
 
-  <!-- 공통 Appender -->
+  <!-- Console Appender -->
   <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <Pattern>${CONSOLE_LOG_PATTERN}</Pattern>
@@ -9,7 +9,21 @@
     </encoder>
   </appender>
 
-  <!--   환경별 설정 -->
+  <!-- File Appender -->
+  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${LOGS_ABSOLUTE_PATH}/app.log</file>
+    <encoder>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <charset>utf8</charset>
+    </encoder>
+    <!-- 하루마다 롤링, gz 압축 -->
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+      <fileNamePattern>${LOGS_ABSOLUTE_PATH}/app.log.%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
+      <maxFileSize>100MB</maxFileSize>
+      <maxHistory>30</maxHistory>
+    </rollingPolicy>
+  </appender>
+
   <springProfile name="local">
     <root level="INFO">
       <appender-ref ref="CONSOLE"/>
@@ -17,6 +31,10 @@
   </springProfile>
 
   <springProfile name="dev,prod">
+
+    <property name="LOGS_ABSOLUTE_PATH" value="~/sbooky/logs"/>
+
+    <!-- Discord Appender -->
     <property resource="logging.yml"/>
     <springProperty name="DISCORD_WEBHOOK_URL" source="logging.discord.webhook-uri"/>
     <appender name="DISCORD" class="com.github.napstr.logback.DiscordAppender">
@@ -37,10 +55,12 @@
         <level>ERROR</level>
       </filter>
     </appender>
+    <!-- Discord Appender -->
 
     <root level="INFO">
       <appender-ref ref="ASYNC_DISCORD"/>
       <appender-ref ref="CONSOLE"/>
+      <appender-ref ref="FILE"/>
     </root>
   </springProfile>
 </configuration>

--- a/api/src/main/resources/logback-spring.xml
+++ b/api/src/main/resources/logback-spring.xml
@@ -1,0 +1,46 @@
+<configuration>
+  <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+  <!-- 공통 Appender -->
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <Pattern>${CONSOLE_LOG_PATTERN}</Pattern>
+      <charset>utf8</charset>
+    </encoder>
+  </appender>
+
+  <!--   환경별 설정 -->
+  <springProfile name="local">
+    <root level="INFO">
+      <appender-ref ref="CONSOLE"/>
+    </root>
+  </springProfile>
+
+  <springProfile name="dev,prod">
+    <property resource="logging.yml"/>
+    <springProperty name="DISCORD_WEBHOOK_URL" source="logging.discord.webhook-uri"/>
+    <appender name="DISCORD" class="com.github.napstr.logback.DiscordAppender">
+      <webhookUri>${DISCORD_WEBHOOK_URL}</webhookUri>
+      <layout class="ch.qos.logback.classic.PatternLayout">
+        <pattern>```%d{yyyy-MM-dd HH:mm:ss} [%thread] [%-5level] %logger{36} - %msg%n```</pattern>
+      </layout>
+      <username>스북이 비상 🚨</username>
+      <avatarUrl>
+        https://private-user-images.githubusercontent.com/84575041/433232772-9dd20d5f-a420-49ad-af81-887d61c8a8ad.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDQ2MTA1MTksIm5iZiI6MTc0NDYxMDIxOSwicGF0aCI6Ii84NDU3NTA0MS80MzMyMzI3NzItOWRkMjBkNWYtYTQyMC00OWFkLWFmODEtODg3ZDYxYzhhOGFkLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTA0MTQlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUwNDE0VDA1NTY1OVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTZmOTE0NDhkY2EzYTQ5MmJmNGM1OGIxZWE0NjQ5ODU4ZjQ1ZDRkYWQ0NTUyMWIxZGI2MzA3ZjNmNzFlMmJmZTEmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.wYCIKDPmASllJs0321vF5QzT6B_qjujPzI-3yKbScBI
+      </avatarUrl>
+      <tts>false</tts>
+    </appender>
+
+    <appender name="ASYNC_DISCORD" class="ch.qos.logback.classic.AsyncAppender">
+      <appender-ref ref="DISCORD"/>
+      <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+        <level>ERROR</level>
+      </filter>
+    </appender>
+
+    <root level="INFO">
+      <appender-ref ref="ASYNC_DISCORD"/>
+      <appender-ref ref="CONSOLE"/>
+    </root>
+  </springProfile>
+</configuration>

--- a/api/src/main/resources/logging.yml
+++ b/api/src/main/resources/logging.yml
@@ -1,0 +1,4 @@
+logging:
+  discord:
+    webhook-url: ${DISCORD_WEBHOOK_URL}
+  config: classpath:logback-spring.xml

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ allprojects {
 
     repositories {
         mavenCentral()
+        maven { url 'https://jitpack.io' }
     }
 }
 


### PR DESCRIPTION
## 연관된 이슈

resolves #170 

## 작업 내용

[DEV | PROD] 환경 기준으로 서버 내부에서 발생하는 `ERROR` 레벨의 로깅이 디스코드 웹훅을 통해 메시지를 발송합니다.

_Example_

<img width="605" alt="image" src="https://github.com/user-attachments/assets/a490a12a-b4d4-4198-bf86-812c9e99770d" />


## 리뷰 요구사항

> .env 파일의 변경이 필요합니다~ 노션에 추가해뒀어요! 

로깅 수준을 `ERROR` 레벨로 지정을 해두긴 했는데, 다른 레벨(`WARN`, `INFO` ...)로 낮춰야 할 필요가 있을까요? 