### PR TITLE
로그를 파일로 남긴다. 

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -56,9 +56,10 @@ jobs:
             docker stop sbooky-app-dev || true
             docker rm -f sbooky-app-dev || true
             docker run -d --name sbooky-app-dev \
-              --network sbooky-network \
-              -p ${{ secrets.DEV_SERVER_PORT }}:8080 \
-              --env-file .env-dev \
-              ${{ secrets.DOCKER_USERNAME }}/sbooky-app-dev:latest
-            
+            --network sbooky-network \
+            -p ${{ secrets.DEV_SERVER_PORT }}:8080 \
+            --env-file .env-dev \
+            -v /home/ubuntu/sbooky/logs:/logs \
+            ${{ secrets.DOCKER_USERNAME }}/sbooky-app-dev:latest
+
             docker image prune -f

--- a/api/src/main/resources/logback-spring.xml
+++ b/api/src/main/resources/logback-spring.xml
@@ -32,7 +32,7 @@
 
   <springProfile name="dev,prod">
 
-    <property name="LOGS_ABSOLUTE_PATH" value="~/sbooky/logs"/>
+    <property name="LOGS_ABSOLUTE_PATH" value="./logs"/>
 
     <!-- Discord Appender -->
     <property resource="logging.yml"/>


### PR DESCRIPTION
## 연관된 이슈

resolves #172 

## 작업 내용

Docker를 사용하는 상황이여서 EC2 내부에 로그 파일을 남기지 못하는 문제를 도커 볼륨을 통해 해결했습니다. 


### Docker Logs

```
ubuntu@:~$ docker logs -f sbooky-app-dev

// Logging Start
:: Spring Boot ::                (v3.3.7)
2025-04-16T07:34:48.594Z  INFO 1 --- [api] [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat started on port 8080 (http) with context path '/dev'
2025-04-16T07:34:48.660Z  INFO 1 --- [api] [           main] com.dnd.sbooky.SbookyApplication         : Started SbookyApplication in 23.145 seconds (process running for 24.803)
```

### Docker Container Logging

```
sh-4.4# cd logs
sh-4.4# cat app.log

// Logging Start 
2025-04-16 07:34:48.594 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat started on port 8080 (http) with context path '/dev'
2025-04-16 07:34:48.660 [main] INFO  com.dnd.sbooky.SbookyApplication - Started SbookyApplication in 23.145 seconds (process running for 24.803)
```

### EC2(Linux) Logging

```
ubuntu@:~/sbooky/logs$ ls
app.log
ubuntu@:~/sbooky/logs$ cat app.log

// Logging Start 
2025-04-16 07:34:48.594 [main] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat started on port 8080 (http) with context path '/dev'
2025-04-16 07:34:48.660 [main] INFO  com.dnd.sbooky.SbookyApplication - Started SbookyApplication in 23.145 seconds (process running for 24.803)
```

## 리뷰 요구사항

