### PR TITLE
책 검색에 캐시를 도입한다.

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -25,4 +25,6 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
     implementation 'com.github.napstr:logback-discord-appender:1.0.0'
+
+    implementation 'com.github.ben-manes.caffeine:caffeine:3.2.0'
 }

--- a/api/src/main/java/com/dnd/sbooky/api/book/v1/SearchBookController.java
+++ b/api/src/main/java/com/dnd/sbooky/api/book/v1/SearchBookController.java
@@ -3,6 +3,7 @@ package com.dnd.sbooky.api.book.v1;
 import com.dnd.sbooky.api.book.v1.response.SearchBookResponse;
 import com.dnd.sbooky.api.docs.spec.SearchBookApiSpec;
 import com.dnd.sbooky.api.support.response.ApiResponse;
+import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,12 +15,36 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class SearchBookController implements SearchBookApiSpec {
 
+    private static final Pattern WHITE_SPACE = Pattern.compile("\\s+");
+    private static final Pattern NON_ALPHANUMERIC = Pattern.compile("[^가-힣a-z0-9]");
+
     private final SearchBookUseCase searchBookUseCase;
 
     @GetMapping("/books")
     public ApiResponse<SearchBookResponse> searchBook(
             @RequestParam String query, @RequestParam(defaultValue = "1") int page) {
 
-        return ApiResponse.success(searchBookUseCase.search(query, page));
+        String normalizeQuery = normalizeQuery(query);
+        return ApiResponse.success(searchBookUseCase.search(normalizeQuery, page));
+    }
+
+    /**
+     * 검색어를 아래와 같은 순서로 정규화합니다.
+     * <ol>
+     *     <li>공백 제거</li>
+     *     <li>알파벳 소문자 변환</li>
+     *     <li>특수 문자 제거</li>
+     * </oi>
+     *
+     * @param query 정규화할 검색어
+     * @return 정규화된 검색어
+     */
+    private String normalizeQuery(String query) {
+
+        String normalizedQuery = WHITE_SPACE.matcher(query).replaceAll("");
+        normalizedQuery = normalizedQuery.toLowerCase();
+        normalizedQuery = NON_ALPHANUMERIC.matcher(normalizedQuery).replaceAll("");
+
+        return normalizedQuery;
     }
 }

--- a/api/src/main/java/com/dnd/sbooky/api/book/v1/SearchBookUseCase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/book/v1/SearchBookUseCase.java
@@ -1,18 +1,52 @@
 package com.dnd.sbooky.api.book.v1;
 
 import com.dnd.sbooky.api.book.v1.response.SearchBookResponse;
+import com.dnd.sbooky.api.support.cache.CustomCacheManager;
 import com.dnd.sbooky.clients.api.BookSearchAdapter;
-import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
-@RequiredArgsConstructor
 public class SearchBookUseCase {
 
     private final BookSearchAdapter bookSearchAdapter;
+    private final CustomCacheManager<SearchBookResponse> cacheManager;
+
+    public SearchBookUseCase(
+            BookSearchAdapter bookSearchAdapter,
+            @Qualifier("caffeineCacheManager") CustomCacheManager<SearchBookResponse> cacheManager) {
+        this.bookSearchAdapter = bookSearchAdapter;
+        this.cacheManager = cacheManager;
+    }
 
     public SearchBookResponse search(String query, int page) {
 
-        return SearchBookResponse.from(bookSearchAdapter.search(query, page));
+        String cacheKey = query + ":" + page;
+
+        return cacheManager
+                .getFromCache(cacheKey)
+                .map(
+                        response -> {
+                            log.debug("[Cache hit] key: {}", cacheKey);
+                            return response;
+                        })
+                .orElseGet(
+                        () -> {
+                            log.debug("[Cache miss] key: {}", cacheKey);
+                            SearchBookResponse response =
+                                    SearchBookResponse.from(bookSearchAdapter.search(query, page));
+
+                            if (isCacheable(response)) {
+                                cacheManager.addToCache(cacheKey, response);
+                                log.debug("[Cache add] key: {}", cacheKey);
+                            }
+                            return response;
+                        });
+    }
+
+    private boolean isCacheable(SearchBookResponse response) {
+        return response.books() != null && !response.books().isEmpty();
     }
 }

--- a/api/src/main/java/com/dnd/sbooky/api/book/v1/SearchBookUseCase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/book/v1/SearchBookUseCase.java
@@ -3,23 +3,17 @@ package com.dnd.sbooky.api.book.v1;
 import com.dnd.sbooky.api.book.v1.response.SearchBookResponse;
 import com.dnd.sbooky.api.support.cache.CustomCacheManager;
 import com.dnd.sbooky.clients.api.BookSearchAdapter;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class SearchBookUseCase {
 
     private final BookSearchAdapter bookSearchAdapter;
     private final CustomCacheManager<SearchBookResponse> cacheManager;
-
-    public SearchBookUseCase(
-            BookSearchAdapter bookSearchAdapter,
-            @Qualifier("caffeineCacheManager") CustomCacheManager<SearchBookResponse> cacheManager) {
-        this.bookSearchAdapter = bookSearchAdapter;
-        this.cacheManager = cacheManager;
-    }
 
     public SearchBookResponse search(String query, int page) {
 

--- a/api/src/main/java/com/dnd/sbooky/api/book/v1/SearchBookUseCase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/book/v1/SearchBookUseCase.java
@@ -24,6 +24,7 @@ public class SearchBookUseCase {
                 .map(
                         response -> {
                             log.debug("[Cache hit] key: {}", cacheKey);
+                            cacheManager.incrementCount(cacheKey);
                             return response;
                         })
                 .orElseGet(

--- a/api/src/main/java/com/dnd/sbooky/api/support/cache/CacheConfig.java
+++ b/api/src/main/java/com/dnd/sbooky/api/support/cache/CacheConfig.java
@@ -1,0 +1,52 @@
+package com.dnd.sbooky.api.support.cache;
+
+import com.dnd.sbooky.api.book.v1.response.SearchBookResponse;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Cache configuration class.
+ *
+ * @author Seungjo, Jeong
+ */
+@Slf4j
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    private static final int COUNT_CACHE_EXPIRATION_MINUTES = 60;
+    private static final int DATA_CACHE_EXPIRATION_MINUTES = 60;
+
+    /**
+     * 1차 캐시: 쿼리 카운트 캐시
+     */
+    @Bean(name = "countCache")
+    public Cache<String, Integer> queryCountCache() {
+        return Caffeine.newBuilder()
+                .initialCapacity(10)
+                .maximumSize(100)
+                .expireAfterWrite(COUNT_CACHE_EXPIRATION_MINUTES, TimeUnit.MINUTES)
+                .build();
+    }
+
+    /**
+     * 2차 캐시: 실제 데이터 캐시 (카카오 API 응답 캐시)
+     */
+    @Bean(name = "dataCache")
+    public Cache<String, SearchBookResponse> caffeineConfig() {
+        return Caffeine.newBuilder()
+                .recordStats()
+                .initialCapacity(10)
+                .maximumSize(30)
+                .evictionListener(
+                        (key, value, cause) ->
+                                log.info("[Cache eviction] key {} was evicted ({}): {}", key, cause, value))
+                .expireAfterWrite(DATA_CACHE_EXPIRATION_MINUTES, TimeUnit.MINUTES)
+                .build();
+    }
+}

--- a/api/src/main/java/com/dnd/sbooky/api/support/cache/CacheLogging.java
+++ b/api/src/main/java/com/dnd/sbooky/api/support/cache/CacheLogging.java
@@ -1,0 +1,55 @@
+package com.dnd.sbooky.api.support.cache;
+
+import com.dnd.sbooky.api.book.v1.response.SearchBookResponse;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * Cache logging class.
+ *
+ * @author Seungjo, Jeong
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CacheLogging {
+
+    private final Cache<String, SearchBookResponse> dataCache;
+
+    /**
+     * 2차 캐시 통계를 로그로 출력합니다.
+     */
+    public void logCacheStats() {
+
+        CacheStats stats = dataCache.stats();
+
+        long requestCount = stats.requestCount();
+        double hitRate = stats.hitRate() * 100;
+        double missRate = stats.missRate() * 100;
+        double avgLoadPenaltyMs = stats.averageLoadPenalty() / 1_000_000.0; // ns → ms
+        double loadFailureRate = stats.loadFailureRate() * 100;
+        double evictionRate =
+                requestCount == 0 ? 0.0 : (double) stats.evictionCount() / requestCount * 100;
+
+        log.info(
+                "[Cache: {}] Hit: {}, Miss: {}, Request: {}, HitRate: {}%, MissRate: {}%, Eviction: {},"
+                        + " EvictionRate: {}%, LoadSuccess: {}, LoadFailure: {}, LoadFailureRate: {}%,"
+                        + " TotalLoadTime(ms): {}, AvgLoadPenalty(ms): {}",
+                "DataCache",
+                stats.hitCount(),
+                stats.missCount(),
+                requestCount,
+                String.format("%.2f", hitRate),
+                String.format("%.2f", missRate),
+                stats.evictionCount(),
+                String.format("%.2f", evictionRate),
+                stats.loadSuccessCount(),
+                stats.loadFailureCount(),
+                String.format("%.2f", loadFailureRate),
+                stats.totalLoadTime() / 1_000_000,
+                String.format("%.2f", avgLoadPenaltyMs));
+    }
+}

--- a/api/src/main/java/com/dnd/sbooky/api/support/cache/CacheScheduler.java
+++ b/api/src/main/java/com/dnd/sbooky/api/support/cache/CacheScheduler.java
@@ -1,0 +1,27 @@
+package com.dnd.sbooky.api.support.cache;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Cache scheduler class.
+ *
+ * @author Seungjo, Jeong
+ */
+@Component
+@EnableScheduling
+@RequiredArgsConstructor
+public class CacheScheduler {
+
+    private final CacheLogging cacheLogging;
+
+    /**
+     * 1시간 마다 캐시 통계를 로그로 출력합니다.
+     */
+    @Scheduled(cron = "0 0 * * * *")
+    public void logCacheStats() {
+        cacheLogging.logCacheStats();
+    }
+}

--- a/api/src/main/java/com/dnd/sbooky/api/support/cache/CaffeineCacheManager.java
+++ b/api/src/main/java/com/dnd/sbooky/api/support/cache/CaffeineCacheManager.java
@@ -1,0 +1,50 @@
+package com.dnd.sbooky.api.support.cache;
+
+import com.dnd.sbooky.api.book.v1.response.SearchBookResponse;
+import com.github.benmanes.caffeine.cache.Cache;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * CaffeineCacheManager class.
+ *
+ * @author Seungjo, Jeong
+ */
+@Component
+@RequiredArgsConstructor
+public class CaffeineCacheManager implements CustomCacheManager<SearchBookResponse> {
+
+    private final Cache<String, Integer> countCache;
+    private final Cache<String, SearchBookResponse> dataCache;
+
+    private static final int THRESHOLD = 10;
+
+    @Override
+    public void addToCache(String key, SearchBookResponse value) {
+
+        Integer count = countCache.asMap().compute(key, (k, v) -> v == null ? 1 : v + 1);
+
+        if (count >= THRESHOLD) {
+            dataCache.put(key, value);
+        }
+    }
+
+    @Override
+    public void clear() {
+        countCache.invalidateAll();
+        dataCache.invalidateAll();
+    }
+
+    @Override
+    public Optional<SearchBookResponse> getFromCache(String key) {
+
+        // 1차 캐시의 카운트가 THRESHOLD 미만인 경우 null을 반환합니다.
+        Integer count = countCache.getIfPresent(key);
+        if (count == null || count < THRESHOLD) {
+            return Optional.empty();
+        }
+
+        return Optional.ofNullable(dataCache.getIfPresent(key));
+    }
+}

--- a/api/src/main/java/com/dnd/sbooky/api/support/cache/CaffeineCacheManager.java
+++ b/api/src/main/java/com/dnd/sbooky/api/support/cache/CaffeineCacheManager.java
@@ -21,9 +21,14 @@ public class CaffeineCacheManager implements CustomCacheManager<SearchBookRespon
     private static final int THRESHOLD = 10;
 
     @Override
+    public Integer incrementCount(String key) {
+        return countCache.asMap().compute(key, (k, v) -> v == null ? 1 : v + 1);
+    }
+
+    @Override
     public void addToCache(String key, SearchBookResponse value) {
 
-        Integer count = countCache.asMap().compute(key, (k, v) -> v == null ? 1 : v + 1);
+        Integer count = incrementCount(key);
 
         if (count >= THRESHOLD) {
             dataCache.put(key, value);

--- a/api/src/main/java/com/dnd/sbooky/api/support/cache/CaffeineCacheManager.java
+++ b/api/src/main/java/com/dnd/sbooky/api/support/cache/CaffeineCacheManager.java
@@ -39,7 +39,6 @@ public class CaffeineCacheManager implements CustomCacheManager<SearchBookRespon
     @Override
     public Optional<SearchBookResponse> getFromCache(String key) {
 
-        // 1차 캐시의 카운트가 THRESHOLD 미만인 경우 null을 반환합니다.
         Integer count = countCache.getIfPresent(key);
         if (count == null || count < THRESHOLD) {
             return Optional.empty();

--- a/api/src/main/java/com/dnd/sbooky/api/support/cache/CustomCacheManager.java
+++ b/api/src/main/java/com/dnd/sbooky/api/support/cache/CustomCacheManager.java
@@ -1,0 +1,17 @@
+package com.dnd.sbooky.api.support.cache;
+
+import java.util.Optional;
+
+/**
+ * Cache Manager interface for SearchBook.
+ *
+ * @author Seungjo, Jeong
+ */
+public interface CustomCacheManager<T> {
+
+    void addToCache(String key, T value);
+
+    void clear();
+
+    Optional<T> getFromCache(String key);
+}

--- a/api/src/main/java/com/dnd/sbooky/api/support/cache/CustomCacheManager.java
+++ b/api/src/main/java/com/dnd/sbooky/api/support/cache/CustomCacheManager.java
@@ -9,6 +9,8 @@ import java.util.Optional;
  */
 public interface CustomCacheManager<T> {
 
+    Integer incrementCount(String key);
+
     void addToCache(String key, T value);
 
     void clear();


### PR DESCRIPTION
## 연관된 이슈

resolves #176 

## 작업 내용

### 1. 캐시 레이어 설계

- 캐시 레이어의 변경 가능성을 고려하여 `CustomCacheManager` 인터페이스 기반으로 확장성 있게 설계하였습니다.
  - 로컬 테스트 환경에서 HashMap, LinkedHashMap 등 다양한 구현체로 검증을 진행하였습니다. ([study/cache 브랜치](https://github.com/dnd-side-project/dnd-12th-9-backend/tree/study/cache/api/src/main/java/com/dnd/sbooky/api/support/cache))
- 글로벌 캐시(Redis)로 전환 시에도 `CustomCacheManager` 구현체만 교체하면 손쉽게 적용 가능합니다.

### 2. 책 검색 결과에 대해서 카페인 캐시 도입

- **1차 캐시**: 각 검색어(정규화된 키) 별 호출 카운트만 저장
- **2차 캐시**: 임계치 이상 검색된 쿼리에 대해서 실제 카카오 API 응답 데이터를 저장

이중 캐시 구조를 통해 불필요한 데이터 캐싱을 방지하고, 실제로 자주 검색되는 데이터의 캐시 히트율을 향상시켰습니다.


### 3. 캐시 관련 로그 처리 

- 캐시 적중률, 만료(eviction), 저장 현황 등을 실시간으로 로그로 남겨 운영 및 모니터링에 활용할 수 있도록 하였습니다.


## 리뷰 요구사항

아직 임계치, 만료 전략(eviction policy), capacity, maximumSize 등 설정하지 않은 부분이 많습니다. 
이 부분에 대해서는 실제 배포 환경에서 모니터링하면서 변경하고자 합니다.