### PR TITLE
완독한 책 삭제가 안되는 에러를 수정한다.

### DIFF
--- a/api/src/main/java/com/dnd/sbooky/api/book/v1/DeleteBookUseCase.java
+++ b/api/src/main/java/com/dnd/sbooky/api/book/v1/DeleteBookUseCase.java
@@ -5,14 +5,18 @@ import com.dnd.sbooky.api.book.v1.exception.BookNotFoundException;
 import com.dnd.sbooky.api.support.error.ErrorType;
 import com.dnd.sbooky.core.book.MemberBookEntity;
 import com.dnd.sbooky.core.book.MemberBookRepository;
+import com.dnd.sbooky.core.evaluation.BookEvaluationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class DeleteBookUseCase {
 
     private final MemberBookRepository memberBookRepository;
+    private final BookEvaluationRepository bookEvaluationRepository;
 
     public void delete(Long memberId, Long memberBookId) {
 
@@ -25,6 +29,10 @@ public class DeleteBookUseCase {
             throw new BookForbiddenException(ErrorType.BOOK_ACCESS_FORBIDDEN);
         }
 
-        memberBookRepository.delete(memberBook);
+        if (bookEvaluationRepository.existsByMemberBookId(memberBookId)) {
+            bookEvaluationRepository.deleteAllByMemberBookId(memberBookId);
+        }
+
+        memberBookRepository.deleteById(memberBookId);
     }
 }


### PR DESCRIPTION
## 연관된 이슈

resolves #178 

## 작업 내용

책 삭제 시 평가가 존재할 경우 삭제가 되지 않는 문제를 해결했습니다.

1. 평가가 존재하는지 확인
2. 평가가 존재한다면, 평가 삭제 

## 리뷰 요구사항

