### PR TITLE
로그아웃을 할 수 있다.

### DIFF
--- a/api/src/main/java/com/dnd/sbooky/api/security/OAuth2LogoutHandler.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/OAuth2LogoutHandler.java
@@ -39,7 +39,13 @@ public class OAuth2LogoutHandler implements LogoutHandler {
 
     private Optional<String> extractRefreshTokenFromCookies(HttpServletRequest request) {
 
-        return Arrays.stream(request.getCookies())
+        Cookie[] cookies = request.getCookies();
+
+        if (cookies == null) {
+            return Optional.empty();
+        }
+
+        return Arrays.stream(cookies)
                 .filter(cookie -> "refreshToken".equals(cookie.getName()))
                 .map(Cookie::getValue)
                 .findFirst();

--- a/api/src/main/java/com/dnd/sbooky/api/security/OAuth2LogoutHandler.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/OAuth2LogoutHandler.java
@@ -3,21 +3,27 @@ package com.dnd.sbooky.api.security;
 import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 
 import com.dnd.sbooky.api.support.RedisKey;
+import com.dnd.sbooky.api.support.error.ErrorType;
+import com.dnd.sbooky.api.support.response.ApiResponse;
 import com.dnd.sbooky.core.RedisRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import java.util.Arrays;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.logout.LogoutHandler;
 import org.springframework.stereotype.Component;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class OAuth2LogoutHandler implements LogoutHandler {
 
+    private final ObjectMapper objectMapper;
     private final RedisRepository redisRepository;
     private final TokenProvider tokenProvider;
 
@@ -25,34 +31,43 @@ public class OAuth2LogoutHandler implements LogoutHandler {
     public void logout(
             HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
 
-        Arrays.stream(request.getCookies())
-              .filter(cookie -> "refreshToken".equals(cookie.getName()))
-              .findFirst()
-              .ifPresentOrElse(
-                      cookie -> {
-                          String refreshToken = cookie.getValue();
+        extractRefreshTokenFromCookies(request)
+                .ifPresentOrElse(
+                        refreshToken -> processLogout(refreshToken, response),
+                        () -> handleMissingToken(response));
+    }
 
-                          log.info("refreshToken 쿠키 값: {}", refreshToken);
-                          if (refreshToken == null || refreshToken.isEmpty()) {
-                              log.warn("로그아웃 실패: Refresh token이 비어 있습니다.");
-                              response.setStatus(SC_BAD_REQUEST);
-                              return;
-                          }
+    private Optional<String> extractRefreshTokenFromCookies(HttpServletRequest request) {
 
-                          String memberId = tokenProvider.getAuthentication(refreshToken).getName();
-                          String redisKey = RedisKey.refreshTokenPrefix + memberId;
-                          boolean deleted = redisRepository.delete(redisKey);
-                          if (deleted) {
-                              log.info(
-                                      "로그아웃 성공: Redis에서 Refresh token 삭제 완료 (사용자: {}).", memberId);
-                          } else {
-                              log.warn(
-                                      "로그아웃 실패: Redis에서 Refresh token을 찾을 수 없습니다 (사용자: {}).", memberId);
-                          }
-                      },
-                      () -> {
-                          log.warn("로그아웃 실패: Refresh token 쿠키를 찾을 수 없습니다.");
-                          response.setStatus(SC_BAD_REQUEST);
-                      });
+        return Arrays.stream(request.getCookies())
+                .filter(cookie -> "refreshToken".equals(cookie.getName()))
+                .map(Cookie::getValue)
+                .findFirst();
+    }
+
+    private void handleMissingToken(HttpServletResponse response) {
+
+        try {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setCharacterEncoding("UTF-8");
+            objectMapper.writeValue(
+                    response.getWriter(), ApiResponse.error(ErrorType.AUTHENTICATION_FAILED));
+        } catch (IOException e) {
+            response.setStatus(SC_BAD_REQUEST);
+        }
+    }
+
+    private void processLogout(String refreshToken, HttpServletResponse response) {
+        if (refreshToken == null
+                || refreshToken.isEmpty()
+                || !tokenProvider.validateToken(refreshToken)) {
+            response.setStatus(SC_BAD_REQUEST);
+            return;
+        }
+
+        String memberId = tokenProvider.getAuthentication(refreshToken).getName();
+        String redisKey = RedisKey.refreshTokenPrefix + memberId;
+        redisRepository.delete(redisKey);
     }
 }

--- a/api/src/main/java/com/dnd/sbooky/api/security/OAuth2LogoutHandler.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/OAuth2LogoutHandler.java
@@ -1,0 +1,58 @@
+package com.dnd.sbooky.api.security;
+
+import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+
+import com.dnd.sbooky.api.support.RedisKey;
+import com.dnd.sbooky.core.RedisRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Arrays;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2LogoutHandler implements LogoutHandler {
+
+    private final RedisRepository redisRepository;
+    private final TokenProvider tokenProvider;
+
+    @Override
+    public void logout(
+            HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+
+        Arrays.stream(request.getCookies())
+              .filter(cookie -> "refreshToken".equals(cookie.getName()))
+              .findFirst()
+              .ifPresentOrElse(
+                      cookie -> {
+                          String refreshToken = cookie.getValue();
+
+                          log.info("refreshToken 쿠키 값: {}", refreshToken);
+                          if (refreshToken == null || refreshToken.isEmpty()) {
+                              log.warn("로그아웃 실패: Refresh token이 비어 있습니다.");
+                              response.setStatus(SC_BAD_REQUEST);
+                              return;
+                          }
+
+                          String memberId = tokenProvider.getAuthentication(refreshToken).getName();
+                          String redisKey = RedisKey.refreshTokenPrefix + memberId;
+                          boolean deleted = redisRepository.delete(redisKey);
+                          if (deleted) {
+                              log.info(
+                                      "로그아웃 성공: Redis에서 Refresh token 삭제 완료 (사용자: {}).", memberId);
+                          } else {
+                              log.warn(
+                                      "로그아웃 실패: Redis에서 Refresh token을 찾을 수 없습니다 (사용자: {}).", memberId);
+                          }
+                      },
+                      () -> {
+                          log.warn("로그아웃 실패: Refresh token 쿠키를 찾을 수 없습니다.");
+                          response.setStatus(SC_BAD_REQUEST);
+                      });
+    }
+}

--- a/api/src/main/java/com/dnd/sbooky/api/security/SecurityConfig.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/SecurityConfig.java
@@ -87,7 +87,7 @@ public class SecurityConfig {
                                 logout
                                         .logoutUrl("/api/logout")
                                         .addLogoutHandler(oAuth2LogoutHandler)
-                                        .deleteCookies("accessToken", "refreshToken")
+                                        .deleteCookies("refreshToken")
                                         .logoutSuccessHandler(
                                                 ((request, response, authentication) ->
                                                         response.setStatus(HttpServletResponse.SC_OK))))

--- a/api/src/main/java/com/dnd/sbooky/api/security/SecurityConfig.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/SecurityConfig.java
@@ -20,7 +20,7 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
-@EnableWebSecurity(debug = true)
+@EnableWebSecurity
 @RequiredArgsConstructor
 @EnableMethodSecurity
 public class SecurityConfig {

--- a/api/src/main/java/com/dnd/sbooky/api/security/SecurityConfig.java
+++ b/api/src/main/java/com/dnd/sbooky/api/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.dnd.sbooky.api.security;
 
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -19,12 +20,13 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
-@EnableWebSecurity
+@EnableWebSecurity(debug = true)
 @RequiredArgsConstructor
 @EnableMethodSecurity
 public class SecurityConfig {
     private final CustomOAuth2UserService oAuth2UserService;
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
+    private final OAuth2LogoutHandler oAuth2LogoutHandler;
     private final TokenAuthenticationFilter tokenAuthenticationFilter;
     private final TokenExceptionFilter tokenExceptionFilter;
     private final FailedAuthenticationEntryPoint failedAuthenticationEntryPoint;
@@ -80,6 +82,15 @@ public class SecurityConfig {
                                         .userInfoEndpoint(c -> c.userService(oAuth2UserService))
                                         .successHandler(oAuth2SuccessHandler)
                                         .failureHandler(oAuth2FailureHandler))
+                .logout(
+                        logout ->
+                                logout
+                                        .logoutUrl("/api/logout")
+                                        .addLogoutHandler(oAuth2LogoutHandler)
+                                        .deleteCookies("accessToken", "refreshToken")
+                                        .logoutSuccessHandler(
+                                                ((request, response, authentication) ->
+                                                        response.setStatus(HttpServletResponse.SC_OK))))
                 .exceptionHandling(
                         exceptionHandling ->
                                 exceptionHandling.authenticationEntryPoint(failedAuthenticationEntryPoint))

--- a/core/src/main/java/com/dnd/sbooky/core/RedisRepository.java
+++ b/core/src/main/java/com/dnd/sbooky/core/RedisRepository.java
@@ -18,4 +18,8 @@ public class RedisRepository {
     public String getData(String key) {
         return (String) redisTemplate.opsForValue().get(key);
     }
+
+    public void delete(String key) {
+        redisTemplate.delete(key);
+    }
 }


### PR DESCRIPTION
## 연관된 이슈

resolves #182 

## 작업 내용

로그인한 회원이 로그아웃을 가능하도록 로그아웃 API 구현 

```mermaid
sequenceDiagram
    participant 클라이언트
    participant 서버
    participant Redis

    클라이언트->>서버: `/api/logout` 로그아웃 요청 (쿠키 포함)
    서버->>서버: 쿠키에서 `refreshToken` 추출
    alt refreshToken 존재
        서버->>서버: refreshToken 유효성 검사
        alt refreshToken이 유효함
            서버->>Redis: redisKey로 refreshToken 삭제
            Redis-->>서버: 삭제 완료 응답
            서버->>클라이언트: 200 OK 반환
        else refreshToken이 유효하지 않음
            서버->>클라이언트: 400 Bad Request 반환
        end
    else refreshToken 없음
        서버->>클라이언트: 401 Unauthorized 에러 응답
    end

```

## 리뷰 요구사항

